### PR TITLE
 CG-10411: Adding .exports for codebases and directories

### DIFF
--- a/src/graph_sitter/core/codebase.py
+++ b/src/graph_sitter/core/codebase.py
@@ -43,6 +43,7 @@ from graph_sitter.core.external_module import ExternalModule
 from graph_sitter.core.file import File, SourceFile
 from graph_sitter.core.function import Function
 from graph_sitter.core.import_resolution import Import
+from graph_sitter.core.export import Export
 from graph_sitter.core.interface import Interface
 from graph_sitter.core.interfaces.editable import Editable
 from graph_sitter.core.interfaces.has_name import HasName
@@ -87,6 +88,7 @@ TSymbol = TypeVar("TSymbol", bound="Symbol")
 TClass = TypeVar("TClass", bound="Class")
 TFunction = TypeVar("TFunction", bound="Function")
 TImport = TypeVar("TImport", bound="Import")
+TExport = TypeVar("TExport", bound="Export")
 TGlobalVar = TypeVar("TGlobalVar", bound="Assignment")
 TInterface = TypeVar("TInterface", bound="Interface")
 TTypeAlias = TypeVar("TTypeAlias", bound="TypeAlias")
@@ -261,6 +263,24 @@ class Codebase(Generic[TSourceFile, TDirectory, TSymbol, TClass, TFunction, TImp
             TImport can be PyImport for Python codebases or TSImport for TypeScript codebases.
         """
         return self.G.get_nodes(NodeType.IMPORT)
+
+    @property
+    def exports(self) -> list[TExport]:
+        """Returns a list of all Export nodes in the codebase.
+
+        Retrieves all Export nodes from the codebase graph. These exports represent all export statements across all files in the codebase,
+        including exports from both internal modules and external packages.
+
+        Args:
+            None
+
+        Returns:
+            list[TExport]: A list of Export nodes representing all exports in the codebase.
+            TExport can be PyExport for Python codebases or TSExport for TypeScript codebases.
+        """
+        if self.language == ProgrammingLanguage.PYTHON:
+            raise NotImplementedError("Exports are not supported for Python codebases since Python does not have an export mechanism.")
+        return self.G.get_nodes(NodeType.EXPORT)
 
     @property
     def external_modules(self) -> list[ExternalModule]:

--- a/src/graph_sitter/core/directory.py
+++ b/src/graph_sitter/core/directory.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
     from graph_sitter.core.function import Function
     from graph_sitter.core.import_resolution import ImportStatement
     from graph_sitter.core.symbol import Symbol
+    from graph_sitter.core.export import Export
+    from graph_sitter.core.import_resolution import Import
 
 import logging
 
@@ -24,10 +26,12 @@ TImportStatement = TypeVar("TImportStatement", bound="ImportStatement")
 TGlobalVar = TypeVar("TGlobalVar", bound="Assignment")
 TClass = TypeVar("TClass", bound="Class")
 TFunction = TypeVar("TFunction", bound="Function")
+TExport = TypeVar("TExport", bound="Export")
+TImport = TypeVar("TImport", bound="Import")
 
 
 @apidoc
-class Directory(Generic[TFile, TSymbol, TImportStatement, TGlobalVar, TClass, TFunction]):
+class Directory(Generic[TFile, TSymbol, TImportStatement, TGlobalVar, TClass, TFunction, TExport, TImport]):
     """Directory representation for codebase.
     GraphSitter abstraction of a file directory that can be used to look for files and symbols within a specific directory.
     """
@@ -119,6 +123,16 @@ class Directory(Generic[TFile, TSymbol, TImportStatement, TGlobalVar, TClass, TF
         return list(chain.from_iterable(f.import_statements for f in self.files))
 
     @property
+    def exports(self) -> list[TExport]:
+        """Get a recursive list of all exports in the directory and its subdirectories."""
+        return list(chain.from_iterable(f.exports for f in self.files))
+
+    @property
+    def imports(self) -> list[TImport]:
+        """Get a recursive list of all imports in the directory and its subdirectories."""
+        return list(chain.from_iterable(f.imports for f in self.files))
+
+    @property
     def global_vars(self) -> list[TGlobalVar]:
         """Get a recursive list of all global variables in the directory and its subdirectories."""
         return list(chain.from_iterable(f.global_vars for f in self.files))
@@ -140,6 +154,14 @@ class Directory(Generic[TFile, TSymbol, TImportStatement, TGlobalVar, TClass, TF
     def get_import_statement(self, name: str) -> TImportStatement | None:
         """Get an import statement by name in the directory and its subdirectories."""
         return next((s for s in self.import_statements if s.name == name), None)
+
+    def get_export(self, name: str) -> TExport | None:
+        """Get an export by name in the directory and its subdirectories."""
+        return next((s for s in self.exports if s.name == name), None)
+
+    def get_import(self, name: str) -> TImport | None:
+        """Get an import by name in the directory and its subdirectories."""
+        return next((s for s in self.imports if s.name == name), None)
 
     def get_global_var(self, name: str) -> TGlobalVar | None:
         """Get a global variable by name in the directory and its subdirectories."""

--- a/tests/unit/python/codebase/test_codebase_exports_raise_error.py
+++ b/tests/unit/python/codebase/test_codebase_exports_raise_error.py
@@ -1,0 +1,16 @@
+import pytest
+from graph_sitter.enums import ProgrammingLanguage
+from graph_sitter.codebase.factory.get_session import get_codebase_session
+
+def test_python_exports_not_supported(tmpdir):
+    """Test that exports are not supported in Python codebases."""
+    # language=python
+    content = """
+def hello():
+    pass
+    """
+    # Create a Python codebase with a simple Python file
+    with get_codebase_session(tmpdir=tmpdir, files={"test.py": content}, programming_language=ProgrammingLanguage.PYTHON) as codebase:
+        # Verify that accessing exports raises NotImplementedError
+        with pytest.raises(NotImplementedError):
+            _ = codebase.exports

--- a/tests/unit/typescript/export/test_codebase_exports.py
+++ b/tests/unit/typescript/export/test_codebase_exports.py
@@ -1,0 +1,52 @@
+from graph_sitter.codebase.factory.get_session import get_codebase_session
+from graph_sitter.enums import ImportType, ProgrammingLanguage
+
+
+def test_codebase_exports(tmpdir) -> None:
+    # language=typescript
+    content = """
+    export const a = 1;
+    export let b = 2;
+    export var c = 3;
+    export function foo() {}
+    export class Bar {}
+    export interface IFoo {}
+    export type MyType = string;
+    export { foo as default };
+    """
+    with get_codebase_session(tmpdir=tmpdir, files={"file.ts": content}, programming_language=ProgrammingLanguage.TYPESCRIPT) as codebase:
+        assert len(codebase.exports) == 8
+        export_names = {exp.name for exp in codebase.exports}
+        assert export_names == {"a", "b", "c", "foo", "Bar", "IFoo", "MyType", "default"}
+
+
+def test_codebase_reexports(tmpdir) -> None:
+    # language=typescript
+    content1 = """
+    export const x = 1;
+    export const y = 2;
+    """
+    content2 = """
+    export { x } from './file1';
+    export { y as z } from './file1';
+    """
+    with get_codebase_session(
+        tmpdir=tmpdir,
+        files={"file1.ts": content1, "file2.ts": content2},
+        programming_language=ProgrammingLanguage.TYPESCRIPT
+    ) as codebase:
+        assert len(codebase.exports) == 4
+        export_names = {exp.name for exp in codebase.exports}
+        assert export_names == {"x", "y", "z"}
+
+
+def test_codebase_default_exports(tmpdir) -> None:
+    # language=typescript
+    content = """
+    const value = 42;
+    export default value;
+    """
+    with get_codebase_session(tmpdir=tmpdir, files={"file.ts": content}, programming_language=ProgrammingLanguage.TYPESCRIPT) as codebase:
+        assert len(codebase.exports) == 1
+        export = codebase.exports[0]
+        assert export.name == "value"

--- a/tests/unit/typescript/export/test_directory_exports.py
+++ b/tests/unit/typescript/export/test_directory_exports.py
@@ -1,0 +1,39 @@
+from graph_sitter.codebase.factory.get_session import get_codebase_session
+from graph_sitter.enums import ProgrammingLanguage
+
+
+def test_directory_exports(tmpdir) -> None:
+    # language=typescript
+    content1 = """
+    export const a = 1;
+    export const b = 2;
+    """
+    content2 = """
+    export const c = 3;
+    export const d = 4;
+    """
+    with get_codebase_session(
+        tmpdir=tmpdir,
+        files={
+            "dir1/file1.ts": content1,
+            "dir1/file2.ts": content2,
+            "dir2/file3.ts": "export const e = 5;"
+        },
+        programming_language=ProgrammingLanguage.TYPESCRIPT
+    ) as codebase:
+        dir1 = codebase.get_directory("dir1")
+        dir2 = codebase.get_directory("dir2")
+        
+        # Test dir1 exports
+        assert len(dir1.exports) == 4
+        dir1_export_names = {exp.name for exp in dir1.exports}
+        assert dir1_export_names == {"a", "b", "c", "d"}
+        
+        # Test dir2 exports
+        assert len(dir2.exports) == 1
+        assert dir2.exports[0].name == "e"
+        
+        # Test get_export method
+        assert dir1.get_export("a") is not None
+        assert dir1.get_export("e") is None
+        assert dir2.get_export("e") is not None

--- a/tests/unit/typescript/import_resolution/test_directory_imports.py
+++ b/tests/unit/typescript/import_resolution/test_directory_imports.py
@@ -1,0 +1,69 @@
+from graph_sitter.codebase.factory.get_session import get_codebase_session
+from graph_sitter.enums import ImportType, ProgrammingLanguage
+
+
+def test_directory_imports(tmpdir) -> None:
+    # language=typescript
+    content1 = """
+    import { a, b } from '../shared';
+    import type { IFoo } from './types';
+    """
+    content2 = """
+    import { c } from '../shared';
+    import defaultExport from './module';
+    """
+    with get_codebase_session(
+        tmpdir=tmpdir,
+        files={
+            "dir1/file1.ts": content1,
+            "dir1/file2.ts": content2,
+            "dir2/file3.ts": "import { d } from '../shared';"
+        },
+        programming_language=ProgrammingLanguage.TYPESCRIPT
+    ) as codebase:
+        dir1 = codebase.get_directory("dir1")
+        dir2 = codebase.get_directory("dir2")
+        
+        # Test dir1 imports
+        assert len(dir1.imports) == 5
+        dir1_import_names = {imp.name for imp in dir1.imports}
+        assert dir1_import_names == {"a", "b", "IFoo", "c", "defaultExport"}
+        
+        # Test dir2 imports
+        assert len(dir2.imports) == 1
+        assert dir2.imports[0].name == "d"
+        
+        # Test get_import method
+        assert dir1.get_import("a") is not None
+        assert dir1.get_import("d") is None
+        assert dir2.get_import("d") is not None
+
+
+def test_directory_nested_imports(tmpdir) -> None:
+    # language=typescript
+    content1 = """
+    import { a } from './module1';
+    """
+    content2 = """
+    import { b } from '../module2';
+    """
+    content3 = """
+    import { c } from '../../module3';
+    """
+    with get_codebase_session(
+        tmpdir=tmpdir,
+        files={
+            "dir1/file1.ts": content1,
+            "dir1/subdir/file2.ts": content2,
+            "dir1/subdir/deepdir/file3.ts": content3
+        },
+        programming_language=ProgrammingLanguage.TYPESCRIPT
+    ) as codebase:
+        dir1 = codebase.get_directory("dir1")
+        subdir = codebase.get_directory("dir1/subdir")
+        deepdir = codebase.get_directory("dir1/subdir/deepdir")
+        
+        # Test imports at each directory level
+        assert len(dir1.imports) == 3  # Should include all nested imports
+        assert len(subdir.imports) == 2  # Should include its own and deeper imports
+        assert len(deepdir.imports) == 1  # Should only include its own imports


### PR DESCRIPTION
# Motivation
<!-- Why is this change necessary? -->
- Adding codebase.exports 
 

Adding the following for directories:
1. directory.imports
2. directory.exports
3. directory.get_import(imp_name)
4. directory.get_export(exp_name)

Also throws error on codebase.exports if calling on a python parsed codebase