### PR TITLE
[WIP] Changes it to create a single package `codegen`

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -1,6 +1,6 @@
 [build.hooks.vcs]
 dependencies = ["hatch-vcs>=0.4.0"]
-version-file = "src/graph_sitter/__init__.py"
+version-file = "src/codegen/__init__.py"
 
 [metadata]
 allow-direct-references = true
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 [build.targets.wheel.hooks.cython.options]
-src = "graph_sitter"
+src = "codegen"
 compile_args = [
     "-O3",
     { platforms = [
@@ -70,11 +70,7 @@ exclude = [
 macos-max-compat = false
 
 [build]
-packages = [
-    "src/graph_sitter",
-    "src/graph_visualization",
-    "src/gscli",
-]
+packages = ["src/codegen"]
 
 [metadata.hooks.vcs]
 Homepage = "https://github.com/codegen-sh/codegen-sdk"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "graph-sitter"
+name = "codegen"
 dynamic = ["version", "urls"]
 description = "Add your description here"
 readme = "README.md"
@@ -61,8 +61,8 @@ classifiers = [
 "Intended Audience :: Developers", "Programming Language :: Python :: 3.12", "Programming Language :: Python :: 3.13", "Topic :: Software Development", "Development Status :: 4 - Beta", "Environment :: MacOS X", "Programming Language :: Python :: 3", "Programming Language :: Python", ]
 
 [project.scripts]
-gs = "gscli.main:main"
-run_string = "graph_sitter.core.main:main"
+gs = "codegen.gscli.main:main"
+run_string = "codegen.graph_sitter.core.main:main"
 [project.optional-dependencies]
 types = [
     "types-networkx>=3.2.1.20240918",


### PR DESCRIPTION
This is not correct, but the idea is:
```
codegen/
├── pyproject.toml
├── README.md
├── src/
│   └── codegen/
│       ├── __init__.py  <---- these imports are manually added
│       ├── sdk/
│       │   ├── __init__.py
│       │   ├── _cython_utils.pyx
│       │   └── core.py
│       ├── cli/
│       │   ├── __init__.py
│       │   └── main.py
│       └── git/
│           ├── __init__.py
│           └── utils.py
└── tests/
    └── test_codegen.py
```

And the hatch build file will compile this