### PR TITLE
Add disable_graph Option / Feature Flag

### DIFF
--- a/src/codegen/sdk/codebase/config.py
+++ b/src/codegen/sdk/codebase/config.py
@@ -42,6 +42,7 @@ class GSFeatureFlags(BaseModel):
     full_range_index: bool = False
     ignore_process_errors: bool = True  # Ignore errors from dependency manager and language engine
     import_resolution_overrides: dict[str, str] = {}  # Override import resolution for specific modules
+    disable_graph: bool = False  # Turn of graph generation entirely. Speeds up parsing but disables usages and dependencies
 
 
 DefaultFlags = GSFeatureFlags(sync_enabled=False)


### PR DESCRIPTION
# Motivation

This adds the ability to turn off import and symbol resolution during codebase parsing. Motivation is to create a (more) lightweight editor for any file-independent changes that do not require the dependency or usage graph.

Prelim testing shows a 25% - 35% in memory usage as well as a 65%-85% reduction in parse times.
