### PR TITLE
CG-10472: Adds docstrings to class attributes missing docstrings

### DIFF
--- a/src/codegen/git/models/pr_options.py
+++ b/src/codegen/git/models/pr_options.py
@@ -5,7 +5,14 @@ from codegen.shared.decorators.docs import apidoc
 
 @apidoc
 class PROptions(BaseModel):
-    """Options for generating a PR."""
+    """Options for generating a PR.
+
+    Attributes:
+        title: The title of the pull request.
+        body: The body content of the pull request.
+        labels: A list of labels to be added to the pull request.
+        force_push_head_branch: A flag indicating whether to force push the head branch.
+    """
 
     title: str | None = None
     body: str | None = None

--- a/src/codegen/sdk/code_generation/doc_utils/generate_docs_json.py
+++ b/src/codegen/sdk/code_generation/doc_utils/generate_docs_json.py
@@ -12,7 +12,7 @@ from codegen.sdk.core.placeholder.placeholder_type import TypePlaceholder
 ATTRIBUTES_TO_IGNORE = ["G", "node_id", "angular"]
 
 
-def generate_docs_json(codebase: Codebase, head_commit: str) -> dict[str, dict[str, Any]]:
+def generate_docs_json(codebase: Codebase, head_commit: str, raise_on_missing_docstring: bool = False) -> dict[str, dict[str, Any]]:
     """Update documentation table for classes, methods and attributes in the codebase.
 
     Args:
@@ -110,22 +110,22 @@ def generate_docs_json(codebase: Codebase, head_commit: str) -> dict[str, dict[s
             return
 
         attr_path = create_path(attr, cls)
-        original_attr_path = create_path(attr)
 
-        if original_attr_path not in attr_cache:
-            description = attr.docstring(cls)
-            attr_return_type = []
-            if r_type := get_type_str(attr):
-                if isinstance(r_type, TypePlaceholder):
-                    resolved_types = []
-                else:
-                    resolved_types = r_type.resolved_types
-                r_type_source = replace_multiple_types(codebase=codebase, input_str=r_type.source, resolved_types=resolved_types, parent_class=cls, parent_symbol=attr, types_cache=types_cache)
-                attr_return_type.append(r_type_source)
+        description = attr.docstring(attr.parent_class)
+        if raise_on_missing_docstring and not description:
+            msg = f"Attribute {attr.parent_class.name}.{attr.name} does not have a docstring"
+            raise ValueError(msg)
+        attr_return_type = []
+        if r_type := get_type_str(attr):
+            if isinstance(r_type, TypePlaceholder):
+                resolved_types = []
+            else:
+                resolved_types = r_type.resolved_types
+            r_type_source = replace_multiple_types(codebase=codebase, input_str=r_type.source, resolved_types=resolved_types, parent_class=cls, parent_symbol=attr, types_cache=types_cache)
+            attr_return_type.append(r_type_source)
 
-            attr_cache[original_attr_path] = {"description": description, "attr_return_type": attr_return_type}
+        attr_info = {"description": description, "attr_return_type": attr_return_type}
 
-        attr_info = attr_cache[original_attr_path]
         meta_data = {"parent": create_path(attr.parent_class), "path": attr.file.filepath}
 
         return MethodDoc(

--- a/src/codegen/sdk/codebase/span.py
+++ b/src/codegen/sdk/codebase/span.py
@@ -54,7 +54,13 @@ RangeAdapter = Annotated[
 
 @apidoc
 class Span(BaseModel):
-    """Range within the codebase"""
+    """Range within the codebase
+
+    Attributes:
+        model_config: Configuration for the model, including JSON encoders.
+        range: Adapter for the range within the codebase.
+        filepath: Path to the file associated with the range.
+    """
 
     model_config = ConfigDict(
         frozen=True,

--- a/src/codegen/sdk/core/assignment.py
+++ b/src/codegen/sdk/core/assignment.py
@@ -46,14 +46,8 @@ class Assignment(Symbol[Parent, ...], Typeable[Parent, ...], HasValue, Generic[P
     """Represents an assignment for a single variable within an assignment statement.
 
     Attributes:
-        left: The left side of the assignment
-        right: The right side of the assignment
-
-    Example:
-        ```typescript
-        var z
-        var z = 5
-        ```
+        _left: The internal representation of the left side of the assignment as an Expression.
+        symbol_type: The type of symbol, set to SymbolType.GlobalVar.
     """
 
     _left: Expression[Self]

--- a/src/codegen/sdk/core/class_definition.py
+++ b/src/codegen/sdk/core/class_definition.py
@@ -51,7 +51,14 @@ TType = TypeVar("TType", bound="Type")
 
 @apidoc
 class Class(Inherits[TType], HasBlock[TCodeBlock, TDecorator], Callable[TParameter, TType], HasAttribute[TFunction | Attribute], Generic[TFunction, TDecorator, TCodeBlock, TParameter, TType]):
-    """Abstract representation of a Class definition."""
+    """Abstract representation of a Class definition.
+
+    Attributes:
+        symbol_type: The type of symbol, set to SymbolType.Class.
+        constructor_keyword: The keyword used to identify the constructor method.
+        parent_classes: The parent classes of this class, if any.
+        _methods: A collection of methods defined in this class.
+    """
 
     symbol_type = SymbolType.Class
     constructor_keyword = None

--- a/src/codegen/sdk/core/codebase.py
+++ b/src/codegen/sdk/core/codebase.py
@@ -106,7 +106,11 @@ PyDirectory = Directory[PyFile, PySymbol, PyImportStatement, PyGlobalVar, PyClas
 class Codebase(Generic[TSourceFile, TDirectory, TSymbol, TClass, TFunction, TImport, TGlobalVar, TInterface, TTypeAlias, TParameter, TCodeBlock]):
     """This class provides the main entrypoint for most programs to analyzing and manipulating codebases.
 
-    It provides a high-level interface to interact with the codebase graph, and provides methods to access and manipulate files, directories, symbols, and other entities in the codebase.
+    Attributes:
+        _op: The repository operator, which can be either a local or remote repository operator.
+        viz: The visualization manager for the codebase.
+        repo_path: The path to the repository.
+        console: The console used for logging and output.
     """
 
     _op: RepoOperator | RemoteRepoOperator

--- a/src/codegen/sdk/core/dataclasses/usage.py
+++ b/src/codegen/sdk/core/dataclasses/usage.py
@@ -25,10 +25,11 @@ class Usage:
     """A reference to an exportable object in a file.
 
     Attributes:
-        match: The exact match of the usage
-        usage_symbol: The symbol this object is used in
-        usage_type: How this symbol was used
-        kind: Where this symbol was used (IE: in a type parameter or in the body of the class, etc)
+        match: The exact match of the usage.
+        usage_symbol: The symbol this object is used in.
+        imported_by: The import statement that brought this symbol into scope, or None if not applicable.
+        usage_type: How this symbol was used.
+        kind: Where this symbol was used (e.g., in a type parameter or in the body of the class).
     """
 
     match: Name | ChainedAttribute | FunctionCall
@@ -62,15 +63,17 @@ class UsageKind(IntEnum):
 
     Attributes:
         SUBCLASS: Used in symbol inheritance.
-        TYPE_ANNOTATION:  Used as a type annotation on a parameter or assignment statement.
+        TYPED_PARAMETER: Used as a typed parameter in a function/method.
+        TYPE_ANNOTATION: Used as a type annotation on a parameter or assignment statement.
         BODY: Usage within the body of a function/method.
         DECORATOR: Usage within a decorator.
-        RETURN_TYPE: Used as a return type annotation
+        RETURN_TYPE: Used as a return type annotation.
         TYPE_DEFINITION: Used in a type alias.
         EXPORTED_SYMBOL: Used in an export statement.
         EXPORTED_WILDCARD: Re-exported by a wildcard export.
         GENERIC: Used as a type parameter to another type.
         IMPORTED: Imported with an import statement.
+        IMPORTED_WILDCARD: Imported with a wildcard import statement.
         DEFAULT_VALUE: Represents a default value in a function/method parameter.
     """
 

--- a/src/codegen/sdk/core/detached_symbols/argument.py
+++ b/src/codegen/sdk/core/detached_symbols/argument.py
@@ -28,7 +28,11 @@ TParameter = TypeVar("TParameter", bound="Parameter")
 
 @apidoc
 class Argument(Expression[Parent], HasName, HasValue, Generic[Parent, TParameter]):
-    """Represents an argument passed into a FunctionCall."""
+    """Represents an argument passed into a FunctionCall.
+
+    Attributes:
+        _pos: The zero-based index of this argument within its parent function call.
+    """
 
     _pos: int
 

--- a/src/codegen/sdk/core/detached_symbols/code_block.py
+++ b/src/codegen/sdk/core/detached_symbols/code_block.py
@@ -45,6 +45,11 @@ class CodeBlock(Expression[Parent], Generic[Parent, TAssignment]):
     function body or class body.
 
     Enables various types of queries and operations on the code block.
+
+    Attributes:
+        level: The indentation level of the code block.
+        parent_block: The parent code block containing this block, or None if it is a top-level block.
+        _statements: A collection of statements that are part of this code block.
     """
 
     level: int

--- a/src/codegen/sdk/core/detached_symbols/function_call.py
+++ b/src/codegen/sdk/core/detached_symbols/function_call.py
@@ -39,11 +39,10 @@ Parent = TypeVar("Parent", bound="Expression | None")
 
 @apidoc
 class FunctionCall(Expression[Parent], HasName, Resolvable, Generic[Parent]):
-    """Abstract representation of a function invocation, e.g. in Python:
-    ```
-    def f():
-        g()  # FunctionCall
-    ```
+    """Abstract representation of a function invocation.
+
+    Attributes:
+        _arg_list: A collection of arguments passed to the function call.
     """
 
     _arg_list: Collection[Argument, Self]

--- a/src/codegen/sdk/core/detached_symbols/parameter.py
+++ b/src/codegen/sdk/core/detached_symbols/parameter.py
@@ -39,7 +39,12 @@ Parent = TypeVar("Parent", bound="Collection[Parameter, Function]")
 
 @apidoc
 class Parameter(Usable[Parent], Typeable[TType, Parent], HasValue, Expression[Parent], Generic[TType, Parent]):
-    """Abstract representation of a parameter in a Function definition."""
+    """Abstract representation of a parameter in a Function definition.
+
+    Attributes:
+        _pos: The 0-based index of this parameter within its parent function's parameter list.
+        _name_node: The node representing the name of the parameter, or None if not applicable.
+    """
 
     _pos: int
     _name_node: Name | None = None

--- a/src/codegen/sdk/core/directory.py
+++ b/src/codegen/sdk/core/directory.py
@@ -40,6 +40,12 @@ TSGlobalVar = TypeVar("TSGlobalVar", bound="Assignment")
 class Directory(Generic[TFile, TSymbol, TImportStatement, TGlobalVar, TClass, TFunction, TImport]):
     """Directory representation for codebase.
     GraphSitter abstraction of a file directory that can be used to look for files and symbols within a specific directory.
+
+    Attributes:
+        path: Absolute path of the directory.
+        dirpath: Relative path of the directory.
+        parent: Parent directory, if any.
+        items: Dictionary containing files and subdirectories within the directory.
     """
 
     path: Path  # Absolute Path

--- a/src/codegen/sdk/core/export.py
+++ b/src/codegen/sdk/core/export.py
@@ -21,7 +21,11 @@ Parent = TypeVar("Parent", bound="Collection[Export, ExportStatement]")
 
 @apidoc
 class Export(Exportable[Parent], Generic[Parent]):
-    """Represents a single symbol being exported."""
+    """Represents a single symbol being exported.
+
+    Attributes:
+        export_statement: The statement representing the export.
+    """
 
     export_statement: ExportStatement
 

--- a/src/codegen/sdk/core/expressions/binary_expression.py
+++ b/src/codegen/sdk/core/expressions/binary_expression.py
@@ -23,7 +23,12 @@ Parent = TypeVar("Parent", bound="Editable")
 
 @apidoc
 class BinaryExpression(Expression[Parent], Chainable, Generic[Parent]):
-    """Represents binary expressions, e.g. all of +,-,*,/, as well as booleaneoperations (and, or) etc."""
+    """Represents binary expressions, e.g. all of +,-,*,/, as well as boolean operations (and, or) etc.
+
+    Attributes:
+        left: The left operand of the binary expression, which can be another expression or None.
+        right: The right operand of the binary expression, which can be another expression or None.
+    """
 
     left: Expression[Self] | None
     right: Expression[Self] | None

--- a/src/codegen/sdk/core/expressions/chained_attribute.py
+++ b/src/codegen/sdk/core/expressions/chained_attribute.py
@@ -27,8 +27,9 @@ Parent = TypeVar("Parent", bound="Expression")
 class ChainedAttribute(Expression[Parent], Resolvable, Generic[Object, Attribute, Parent]):
     """An attribute of an object. (IE a method on a class, a function from a module, etc)
 
-    Examples:
-     A.method()
+    Attributes:
+        _object: The object part of the chained attribute expression.
+        _attribute: The attribute part of the chained attribute expression.
     """
 
     _object: Object

--- a/src/codegen/sdk/core/expressions/expression.py
+++ b/src/codegen/sdk/core/expressions/expression.py
@@ -13,7 +13,11 @@ Parent = TypeVar("Parent", bound="Editable")
 
 @apidoc
 class Expression(Editable[Parent], Generic[Parent]):
-    """Represents an arbitrary Expression, such as List, Dict, Binary Expression, String."""
+    """Represents an arbitrary Expression, such as List, Dict, Binary Expression, String.
+
+    Attributes:
+        node_type: The type of the node, set to NodeType.EXPRESSION.
+    """
 
     node_type: NodeType = NodeType.EXPRESSION
 

--- a/src/codegen/sdk/core/expressions/generic_type.py
+++ b/src/codegen/sdk/core/expressions/generic_type.py
@@ -27,7 +27,11 @@ Parent = TypeVar("Parent", bound="Editable")
 
 @apidoc
 class GenericType(NamedType[Parent], Generic[TType, Parent]):
-    """Abstract representation of the generic types of the programming language."""
+    """Abstract representation of the generic types of the programming language.
+
+    Attributes:
+        _parameters: A collection of generic type parameters associated with this type.
+    """
 
     _parameters: Collection[TType, Self]
 

--- a/src/codegen/sdk/core/expressions/multi_expression.py
+++ b/src/codegen/sdk/core/expressions/multi_expression.py
@@ -21,7 +21,11 @@ TExpression = TypeVar("TExpression", bound="Expression")
 
 @apidoc
 class MultiExpression(Expression[Parent], Generic[Parent, TExpression]):
-    """Represents an group of Expressions, such as List, Dict, Binary Expression, String."""
+    """Represents an group of Expressions, such as List, Dict, Binary Expression, String.
+
+    Attributes:
+        expressions: A list of expressions contained within the MultiExpression.
+    """
 
     expressions: list[TExpression]
 

--- a/src/codegen/sdk/core/expressions/string.py
+++ b/src/codegen/sdk/core/expressions/string.py
@@ -25,8 +25,9 @@ class String(Expression[Parent], Builtin, Generic[Parent]):
     """GraphSitter representation of String.
 
     Attributes:
-        content: The content of the string
-        expressions: embedded expressions in the string, only applicable for templated or formatted strings
+        content: The content of the string.
+        content_nodes: A collection of string fragments and escape sequences in TS, or a single string content in Python.
+        expressions: Embedded expressions in the string, only applicable for templated or formatted strings.
     """
 
     content: str

--- a/src/codegen/sdk/core/expressions/subscript_expression.py
+++ b/src/codegen/sdk/core/expressions/subscript_expression.py
@@ -24,6 +24,10 @@ Parent = TypeVar("Parent", bound="Expression")
 class SubscriptExpression(Expression[Parent], Resolvable[Parent], Generic[Object, Index, Parent]):
     """Indexing onto an object (Aka using brackets on an object)
 
+    Attributes:
+        object: The object being indexed.
+        indices: A list of indices used for indexing the object.
+
     Examples:
      A[]
     """

--- a/src/codegen/sdk/core/expressions/ternary_expression.py
+++ b/src/codegen/sdk/core/expressions/ternary_expression.py
@@ -19,7 +19,13 @@ Parent = TypeVar("Parent", bound="Editable")
 
 @apidoc
 class TernaryExpression(Expression[Parent], Chainable, Generic[Parent]):
-    """Any ternary expression in the code where a condition will determine branched execution."""
+    """Any ternary expression in the code where a condition will determine branched execution.
+
+    Attributes:
+        condition: The condition expression that determines which branch to execute.
+        consequence: The expression to execute if the condition is true.
+        alternative: The expression to execute if the condition is false.
+    """
 
     condition: Expression[Self] | None
     consequence: Expression[Self] | None

--- a/src/codegen/sdk/core/external_module.py
+++ b/src/codegen/sdk/core/external_module.py
@@ -29,9 +29,11 @@ class ExternalModule(
 ):
     """Represents an external module, like `datetime`, that can be referenced.
 
-    These are only added to the graph during import resolution and will not exist in a local file's
-    subgraph. This is because we don't know what an import is referencing or resolves to until we
-    see the full codebase.
+    These are only added to the graph during import resolution and will not exist in a local file's subgraph. This is because we don't know what an import is referencing or resolves to until we see
+    the full codebase.
+
+    Attributes:
+        node_type: The type of the node, set to NodeType.EXTERNAL.
     """
 
     node_type: Literal[NodeType.EXTERNAL] = NodeType.EXTERNAL

--- a/src/codegen/sdk/core/file.py
+++ b/src/codegen/sdk/core/file.py
@@ -54,6 +54,17 @@ class File(Editable[None]):
     """Represents a generic file.
 
     Could represent a source file or a non-code file such as a markdown file or image file.
+
+    Attributes:
+        name: The name of the file.
+        file_path: The relative file path as a string.
+        path: The absolute path of the file as a Path object.
+        node_type: The type of node, set to NodeType.FILE.
+        _pending_content_bytes: The pending content of the file in bytes, or None if not set.
+        _directory: The directory containing this file, or None if not set.
+        _pending_imports: A set of pending import strings.
+        _binary: A boolean indicating if the file is binary.
+        _range_index: The range index for the file.
     """
 
     name: str
@@ -430,8 +441,9 @@ class SourceFile(
 ):
     """Represents a file with source code in the codebase.
 
-    Enables creating, reading, updating, and deleting files and searching through their contents,
-    etc.
+    Attributes:
+        code_block: The code block associated with this source file.
+        _nodes: A list of importable nodes contained in the file.
     """
 
     code_block: TCodeBlock

--- a/src/codegen/sdk/core/function.py
+++ b/src/codegen/sdk/core/function.py
@@ -50,7 +50,7 @@ class Function(
     """Abstract representation of a Function.
 
     Attributes:
-        return_type: the return type annotation of the function
+        symbol_type: The type of symbol, set to SymbolType.Function.
     """
 
     symbol_type = SymbolType.Function

--- a/src/codegen/sdk/core/import_resolution.py
+++ b/src/codegen/sdk/core/import_resolution.py
@@ -70,8 +70,13 @@ class Import(Usable[ImportStatement], Chainable, Generic[TSourceFile]):
     from a.b import c, d  # one import for each `c` and `d`
     ```
     Attributes:
+        to_file_id: The node ID of the file to which this import belongs.
+        module: The module being imported, if applicable.
         symbol_name: The name of the symbol being imported. For instance import a as b has a symbol_name of a.
-        import_statement: the ImportStatement that this import belongs to
+        alias: The alias of the imported symbol, if applicable.
+        node_type: The type of node, set to NodeType.IMPORT.
+        import_type: The type of import, indicating how the symbol is imported.
+        import_statement: The ImportStatement that this import belongs to.
     """
 
     to_file_id: NodeId

--- a/src/codegen/sdk/core/interfaces/callable.py
+++ b/src/codegen/sdk/core/interfaces/callable.py
@@ -43,6 +43,10 @@ class Callable(Usable, Generic[TParameter, TType]):
     """Any symbol that can be invoked with arguments eg.
 
     Function, Class, Decorator, ExternalModule
+
+    Attributes:
+        _parameters: The parameters of the callable, stored as a SymbolGroup or a list.
+        return_type: The return type of the callable, which can be a specific type or a placeholder.
     """
 
     _parameters: SymbolGroup[TParameter, Self] | list[TParameter]

--- a/src/codegen/sdk/core/interfaces/editable.py
+++ b/src/codegen/sdk/core/interfaces/editable.py
@@ -99,8 +99,14 @@ T = TypeVar("T", bound="Editable")
 class Editable(JSONable, Generic[Parent]):
     """An editable instance is an abstract text representation of any text in a file.
 
-    The editable APIs enables text search and edit within the given Editable wrapper around any
-    group of text in a file.
+    Attributes:
+        ts_node: The TreeSitter node associated with this Editable instance.
+        file_node_id: The unique identifier for the file node in the codebase graph.
+        G: The codebase graph that this Editable instance is part of.
+        parent: The parent node of this Editable instance.
+        node_type: The type of node this Editable instance represents.
+        _file: The file object that this Editable instance belongs to, or None if not set.
+        _hash: Cached hash value for this Editable instance, or None if not computed.
     """
 
     ts_node: TSNode

--- a/src/codegen/sdk/core/interfaces/has_block.py
+++ b/src/codegen/sdk/core/interfaces/has_block.py
@@ -23,7 +23,11 @@ TDecorator = TypeVar("TDecorator", bound="Decorator")
 
 @apidoc
 class HasBlock(Expression, Generic[TCodeBlock, TDecorator]):
-    """An interface for any code object that has a block of code, e.g. a function, class, etc."""
+    """An interface for any code object that has a block of code, e.g. a function, class, etc.
+
+    Attributes:
+        code_block: The block of code associated with the code object.
+    """
 
     code_block: TCodeBlock
 

--- a/src/codegen/sdk/core/interfaces/has_name.py
+++ b/src/codegen/sdk/core/interfaces/has_name.py
@@ -10,7 +10,11 @@ from codegen.shared.decorators.docs import apidoc, noapidoc
 
 @apidoc
 class HasName:
-    """An interface for any node object that has a name."""
+    """An interface for any node object that has a name.
+
+    Attributes:
+        _name_node: The underlying name node of the object, which can be a Name, ChainedAttribute, DefinedName, or None if no name node is associated.
+    """
 
     _name_node: Name | ChainedAttribute | DefinedName | None = None
 

--- a/src/codegen/sdk/core/interfaces/has_value.py
+++ b/src/codegen/sdk/core/interfaces/has_value.py
@@ -5,7 +5,11 @@ from codegen.shared.decorators.docs import apidoc
 
 @apidoc
 class HasValue:
-    """An interface for any node object that has a value."""
+    """An interface for any node object that has a value.
+
+    Attributes:
+        _value_node: The underlying Expression node that holds the value. Can be None if no value is set.
+    """
 
     _value_node: Expression | None
 

--- a/src/codegen/sdk/core/interfaces/supports_generic.py
+++ b/src/codegen/sdk/core/interfaces/supports_generic.py
@@ -15,6 +15,12 @@ TType = TypeVar("TType", bound="Type")
 
 
 class SupportsGenerics(Symbol, Generic[TType]):
+    """A symbol that supports generics.
+
+    Attributes:
+        type_parameters: The type parameters of the symbol, if any.
+    """
+
     type_parameters: TypeParameters[TType, Self] | None = None
 
     @cached_property

--- a/src/codegen/sdk/core/placeholder/placeholder.py
+++ b/src/codegen/sdk/core/placeholder/placeholder.py
@@ -15,8 +15,8 @@ Parent = TypeVar("Parent", bound="Editable")
 class Placeholder(ABC, Generic[Parent]):
     """A placeholder for a node that does not exist yet.
 
-    Use bool checks (ie is node) to check if the node exists. You can call edit to replace the
-    placeholder with a real node and it will automatically insert formatting.
+    Attributes:
+        _parent_node: The parent node associated with this placeholder.
     """
 
     _parent_node: Parent

--- a/src/codegen/sdk/core/statements/assignment_statement.py
+++ b/src/codegen/sdk/core/statements/assignment_statement.py
@@ -35,6 +35,12 @@ class AssignmentStatement(Statement[TCodeBlock], HasValue, Generic[TCodeBlock, T
     This includes potentially multiple Assignments via `statement.assignments`, which represent each assignment of a value to a variable within this statement.
 
     For example, assigning to a destructured object, or assigning multiple values to multiple variables in a single statement.
+
+    Attributes:
+        statement_type: The type of the statement, set to StatementType.ASSIGNMENT.
+        assignments: A list of assignments within the statement.
+        left: The left-hand side expression of the first assignment.
+        right: The right-hand side expression of the first assignment, or None if not applicable.
     """
 
     statement_type = StatementType.ASSIGNMENT

--- a/src/codegen/sdk/core/statements/attribute.py
+++ b/src/codegen/sdk/core/statements/attribute.py
@@ -30,7 +30,12 @@ TAssignment = TypeVar("TAssignment", bound="Assignment")
 
 @apidoc
 class Attribute(AssignmentStatement[TCodeBlock, TAssignment], Usable, Chainable, Generic[TCodeBlock, TAssignment]):
-    """Abstract representation of an attribute on a class definition."""
+    """Abstract representation of an attribute on a class definition.
+
+    Attributes:
+        statement_type: The type of statement, set to StatementType.CLASS_ATTRIBUTE.
+        assignment: The assignment associated with the attribute.
+    """
 
     statement_type = StatementType.CLASS_ATTRIBUTE
     assignment: TAssignment

--- a/src/codegen/sdk/core/statements/block_statement.py
+++ b/src/codegen/sdk/core/statements/block_statement.py
@@ -25,7 +25,11 @@ TCodeBlock = TypeVar("TCodeBlock", bound="CodeBlock")
 
 @apidoc
 class BlockStatement(Statement[TCodeBlock], HasBlock, ABC, Generic[TCodeBlock]):
-    """Statement which contains a block."""
+    """Statement which contains a block.
+
+    Attributes:
+        code_block: The code block contained within the statement, if any.
+    """
 
     code_block: TCodeBlock | None
 

--- a/src/codegen/sdk/core/statements/comment.py
+++ b/src/codegen/sdk/core/statements/comment.py
@@ -41,7 +41,11 @@ TCodeBlock = TypeVar("TCodeBlock", bound="CodeBlock")
 
 @apidoc
 class Comment(Statement[TCodeBlock], Generic[TCodeBlock]):
-    """Abstract representation of comment statements."""
+    """Abstract representation of comment statements.
+
+    Attributes:
+        statement_type: The type of statement, set to StatementType.COMMENT.
+    """
 
     statement_type = StatementType.COMMENT
 

--- a/src/codegen/sdk/core/statements/export_statement.py
+++ b/src/codegen/sdk/core/statements/export_statement.py
@@ -29,7 +29,8 @@ class ExportStatement(Statement["TSCodeBlock"], Generic[TExport]):
     statement can export multiple symbols from a single source.
 
     Attributes:
-        exports: A list of the individual exports this statement represents
+        exports: A collection of the individual exports this statement represents.
+        statement_type: The type of statement, set to StatementType.EXPORT_STATEMENT.
     """
 
     exports: Collection[TExport, Self]

--- a/src/codegen/sdk/core/statements/expression_statement.py
+++ b/src/codegen/sdk/core/statements/expression_statement.py
@@ -41,6 +41,9 @@ class ExpressionStatement(Statement, HasValue, IWrapper, Generic[Parent, TCodeBl
     x = 1;
     ```
     The above code is also an expression statement, but its expression value is an assignment excluding the semicolon.
+
+    Attributes:
+        statement_type: The type of the statement, set to StatementType.EXPRESSION_STATEMENT.
     """
 
     statement_type = StatementType.EXPRESSION_STATEMENT

--- a/src/codegen/sdk/core/statements/for_loop_statement.py
+++ b/src/codegen/sdk/core/statements/for_loop_statement.py
@@ -26,7 +26,9 @@ class ForLoopStatement(BlockStatement[Parent], HasBlock, ABC, Generic[Parent]):
     """Abstract representation of the for loop.
 
     Attributes:
-        code_block: The code block that is executed in each iteration of the loop
+        statement_type: The type of statement, set to StatementType.FOR_LOOP_STATEMENT.
+        item: The item in the iteration, or None if not applicable.
+        iterable: The expression representing the iterable object.
     """
 
     statement_type = StatementType.FOR_LOOP_STATEMENT

--- a/src/codegen/sdk/core/statements/if_block_statement.py
+++ b/src/codegen/sdk/core/statements/if_block_statement.py
@@ -28,6 +28,7 @@ TCodeBlock = TypeVar("TCodeBlock", bound="CodeBlock")
 @apidoc
 class IfBlockStatement(Statement[TCodeBlock], Generic[TCodeBlock, TIfBlockStatement]):
     """Abstract representation of the if/elif/else if/else statement block.
+
     For example, if there is a code block like:
     if condition1:
         block1
@@ -38,8 +39,11 @@ class IfBlockStatement(Statement[TCodeBlock], Generic[TCodeBlock, TIfBlockStatem
     This class represents the entire block, including the conditions and nested code blocks.
 
     Attributes:
-        condition: The condition expression for the if block. None if the block is an else block.
+        statement_type: The type of statement, set to StatementType.IF_BLOCK_STATEMENT.
+        condition: The condition expression for the if block, or None if it is an else block.
         consequence_block: The code block that is executed if the condition is True.
+        _alternative_blocks: List of alternative blocks (elif/else) or None if it is an elif or else block.
+        _main_if_block: The main if block in the if/elif/else chain.
     """
 
     statement_type = StatementType.IF_BLOCK_STATEMENT

--- a/src/codegen/sdk/core/statements/raise_statement.py
+++ b/src/codegen/sdk/core/statements/raise_statement.py
@@ -25,10 +25,14 @@ Parent = TypeVar("Parent", bound="CodeBlock")
 class RaiseStatement(Statement[Parent], HasValue, Generic[Parent]):
     """Abstract representation of raise statements, e.g. in Python:
 
-    ```python
-    def f(x):
-        raise ValueError()
-    ```
+    Attributes:
+        statement_type: The type of the statement, set to StatementType.RAISE_STATEMENT.
+
+    Example:
+        ```python
+        def f(x):
+            raise ValueError()
+        ```
     """
 
     statement_type = StatementType.RAISE_STATEMENT

--- a/src/codegen/sdk/core/statements/return_statement.py
+++ b/src/codegen/sdk/core/statements/return_statement.py
@@ -27,13 +27,8 @@ TCodeBlock = TypeVar("TCodeBlock", bound="CodeBlock")
 class ReturnStatement(Statement, HasValue, Generic[Parent, TCodeBlock]):
     """Abstract representation of return statements, e.g. in Python:
 
-    ```python
-    def f(x):
-        if x:
-            return x**2  # ReturnStatement
-        else:
-            return 1  # ReturnStatement
-    ```
+    Attributes:
+        statement_type: The type of statement, set to StatementType.RETURN_STATEMENT.
     """
 
     statement_type = StatementType.RETURN_STATEMENT

--- a/src/codegen/sdk/core/statements/statement.py
+++ b/src/codegen/sdk/core/statements/statement.py
@@ -25,7 +25,29 @@ if TYPE_CHECKING:
 
 @apidoc
 class StatementType(StrEnum):
-    """Enum representing the different types of statements that can be parsed."""
+    """Enum representing the different types of statements that can be parsed.
+
+    Attributes:
+        COMMENT: Represents a comment statement.
+        ASSIGNMENT: Represents an assignment expression.
+        EXPRESSION_STATEMENT: Represents an expression statement.
+        CLASS_ATTRIBUTE: Represents a class attribute.
+        RETURN_STATEMENT: Represents a return statement.
+        RAISE_STATEMENT: Represents a raise statement.
+        WITH_STATEMENT: Represents a with statement.
+        PASS_STATEMENT: Represents a pass statement.
+        BREAK_STATEMENT: Represents a break statement.
+        LABELED_STATEMENT: Represents a labeled statement.
+        TRY_CATCH_STATEMENT: Represents a try-catch statement.
+        IF_BLOCK_STATEMENT: Represents an if block statement.
+        FOR_LOOP_STATEMENT: Represents a for loop statement.
+        WHILE_STATEMENT: Represents a while loop statement.
+        SWITCH_STATEMENT: Represents a switch statement.
+        SYMBOL_STATEMENT: Represents a symbol statement.
+        UNSPECIFIED: Represents any unparsed code snippet or graph node statements.
+        EXPORT_STATEMENT: Represents an export statement.
+        IMPORT_STATEMENT: Represents an import statement.
+    """
 
     COMMENT = "comment"
     ASSIGNMENT = "assignment_expression"
@@ -54,7 +76,12 @@ Parent = TypeVar("Parent", bound="CodeBlock")
 
 @apidoc
 class Statement(Expression[Parent], Generic[Parent]):
-    """Represents a single code statement, e.g. a function definition, an assignment, an if/else statement, etc."""
+    """Represents a single code statement, e.g. a function definition, an assignment, an if/else statement, etc.
+
+    Attributes:
+        statement_type: The type of the statement, default is StatementType.UNSPECIFIED.
+        _pos: The position of the statement within its parent code block.
+    """
 
     statement_type: StatementType = StatementType.UNSPECIFIED
     _pos: int

--- a/src/codegen/sdk/core/statements/switch_statement.py
+++ b/src/codegen/sdk/core/statements/switch_statement.py
@@ -26,7 +26,9 @@ class SwitchStatement(Statement[Parent], Generic[Parent, TCodeBlock, TSwitchCase
     """Abstract representation of the switch statement.
 
     Attributes:
-        value: The value to switch on
+        statement_type: The type of statement, set to StatementType.SWITCH_STATEMENT.
+        value: The value to switch on.
+        cases: A list of switch cases associated with the switch statement.
     """
 
     statement_type = StatementType.SWITCH_STATEMENT

--- a/src/codegen/sdk/core/statements/symbol_statement.py
+++ b/src/codegen/sdk/core/statements/symbol_statement.py
@@ -27,8 +27,10 @@ Child = TypeVar("Child", bound="Symbol")
 class SymbolStatement(Statement[Parent], Generic[Parent, Child]):
     """A statement that represents a symbol definition in a codeblock.
 
-    Examples include:
-    - a function definition, class definition, global variable assignment
+    Attributes:
+        statement_type: The type of statement, set to StatementType.SYMBOL_STATEMENT.
+        symbol: The symbol this statement defines, parsed from the code.
+
     """
 
     statement_type = StatementType.SYMBOL_STATEMENT

--- a/src/codegen/sdk/core/statements/try_catch_statement.py
+++ b/src/codegen/sdk/core/statements/try_catch_statement.py
@@ -20,7 +20,7 @@ class TryCatchStatement(BlockStatement[Parent], HasBlock, ABC, Generic[Parent]):
     """Abstract representation of the try catch statement block.
 
     Attributes:
-        code_block: The code block that may trigger an exception
+        statement_type: The type of statement, set to StatementType.TRY_CATCH_STATEMENT.
         finalizer: The code block executed regardless of if an exception is thrown or not
     """
 

--- a/src/codegen/sdk/core/statements/while_statement.py
+++ b/src/codegen/sdk/core/statements/while_statement.py
@@ -26,7 +26,13 @@ TCodeBlock = TypeVar("TCodeBlock", bound="CodeBlock")
 
 @apidoc
 class WhileStatement(Statement[TCodeBlock], HasBlock, ABC, Generic[TCodeBlock]):
-    """Abstract representation of the while statement block."""
+    """Abstract representation of the while statement block.
+
+    Attributes:
+        statement_type: The type of statement, set to StatementType.WHILE_STATEMENT.
+        condition: The condition expression of the while statement.
+        code_block: The code block that represents the body of the while statement.
+    """
 
     statement_type = StatementType.WHILE_STATEMENT
     condition: Expression[Self]

--- a/src/codegen/sdk/core/symbol.py
+++ b/src/codegen/sdk/core/symbol.py
@@ -40,9 +40,11 @@ TCodeBlock = TypeVar("TCodeBlock", bound="CodeBlock")
 
 @apidoc
 class Symbol(Usable[Statement["CodeBlock[Parent, ...]"]], Generic[Parent, TCodeBlock]):
-    """Abstract representation of a Symbol in a Codebase. A Symbol is a top-level entity in a file,
-    e.g. a Function, Class, GlobalVariable, etc.
+    """Abstract representation of a Symbol in a Codebase. A Symbol is a top-level entity in a file, e.g. a Function, Class, GlobalVariable, etc.
 
+    Attributes:
+        symbol_type: The type of the symbol.
+        node_type: The type of the node, set to NodeType.SYMBOL.
     """
 
     symbol_type: SymbolType

--- a/src/codegen/sdk/core/symbol_group.py
+++ b/src/codegen/sdk/core/symbol_group.py
@@ -26,6 +26,9 @@ Parent = TypeVar("Parent", bound="Editable")
 class SymbolGroup(Editable[Parent], Collection[Child], Generic[Child, Parent]):
     """These are groups of symbols that form some kind of logical grouping, like a class or module,
     that do not follow the traditional tree structure.
+
+    Attributes:
+        _symbols: A list of child symbols that belong to this group.
     """
 
     _symbols: list[Child]

--- a/src/codegen/sdk/core/symbol_groups/comment_group.py
+++ b/src/codegen/sdk/core/symbol_groups/comment_group.py
@@ -16,7 +16,11 @@ Parent = TypeVar("Parent")
 
 @apidoc
 class CommentGroup(SymbolGroup[Comment, Parent]):
-    """A group of comments that form a larger comment block."""
+    """A group of comments that form a larger comment block.
+
+    Attributes:
+        _indentation: Indentation level of the comment block.
+    """
 
     _indentation: int  # Indentation level of the comment block
 

--- a/src/codegen/sdk/core/symbol_groups/dict.py
+++ b/src/codegen/sdk/core/symbol_groups/dict.py
@@ -27,7 +27,11 @@ Parent = TypeVar("Parent", bound="Editable")
 
 @apidoc
 class Pair(Editable[Parent], HasValue, Generic[TExpression, Parent]):
-    """An abstract representation of a key, value pair belonging to a `Dict`"""
+    """An abstract representation of a key, value pair belonging to a `Dict`
+
+    Attributes:
+        key: The key expression of the pair, expected to be of type TExpression.
+    """
 
     key: TExpression
 
@@ -77,7 +81,10 @@ Parent = TypeVar("Parent", bound="Editable")
 class Dict(Expression[Parent], Builtin, MutableMapping[str, TExpression], Generic[TExpression, Parent]):
     """Represents a dict (object) literal the source code.
 
-    You can use standard Python operations to operate on this dict (i.e. `len`, `del`, `set`, `get`, etc)
+    Attributes:
+        _underlying: A collection of pairs or unpacked elements representing the
+            underlying structure of the dict.
+        unpack: An optional unpacked element if present in the dict.
     """
 
     _underlying: Collection[Pair[TExpression, Self] | Unpack[Self], Parent]

--- a/src/codegen/sdk/core/symbol_groups/multi_line_collection.py
+++ b/src/codegen/sdk/core/symbol_groups/multi_line_collection.py
@@ -23,6 +23,11 @@ class MultiLineCollection(Collection[Child, Parent], Generic[Child, Parent]):
 
     Example: A list of function definitions, class definitions
     You can use standard operations to operate on this list (IE len, del, append, insert, etc)
+
+    Attributes:
+        _inserts_max_size: A dictionary mapping indices to their maximum insert sizes.
+        _leading_delimiter: The delimiter used at the beginning of the collection.
+        _trailing_delimiter: The delimiter used at the end of the collection.
     """
 
     _inserts_max_size: dict[int, int]

--- a/src/codegen/sdk/core/type_alias.py
+++ b/src/codegen/sdk/core/type_alias.py
@@ -32,6 +32,10 @@ class TypeAlias(SupportsGenerics, HasValue, HasBlock, HasAttribute[TAttribute], 
     """Abstract representation of a Type object.
 
     Only applicable for some programming languages like TypeScript.
+
+    Attributes:
+        symbol_type: The type of symbol, set to SymbolType.Interface.
+        code_block: The code block associated with this type alias.
     """
 
     symbol_type = SymbolType.Interface

--- a/src/codegen/sdk/python/class_definition.py
+++ b/src/codegen/sdk/python/class_definition.py
@@ -25,7 +25,12 @@ from codegen.shared.decorators.docs import noapidoc, py_apidoc
 
 @py_apidoc
 class PyClass(Class[PyFunction, PyDecorator, PyCodeBlock, PyParameter, PyType], PyHasBlock, PySymbol):
-    """Extends Class for Python codebases"""
+    """Extends Class for Python codebases
+
+    Attributes:
+        _decorated_node: The node representing the decorated element, if any.
+        constructor_keyword: The keyword used for the constructor method, set to "__init__".
+    """
 
     _decorated_node: TSNode | None
     constructor_keyword = "__init__"

--- a/src/codegen/sdk/python/file.py
+++ b/src/codegen/sdk/python/file.py
@@ -25,7 +25,11 @@ if TYPE_CHECKING:
 
 @py_apidoc
 class PyFile(SourceFile[PyImport, PyFunction, PyClass, PyAssignment, Interface[PyCodeBlock, PyAttribute, PyFunction, PyType], PyCodeBlock], PyHasBlock):
-    """SourceFile representation for Python codebase"""
+    """SourceFile representation for Python codebase
+
+    Attributes:
+        programming_language: The programming language of the file. Set to ProgrammingLanguage.PYTHON.
+    """
 
     programming_language = ProgrammingLanguage.PYTHON
 

--- a/src/codegen/sdk/python/function.py
+++ b/src/codegen/sdk/python/function.py
@@ -32,7 +32,11 @@ logger = logging.getLogger(__name__)
 
 @py_apidoc
 class PyFunction(Function["PyFunction", PyDecorator, PyCodeBlock, PyParameter, PyType], PyHasBlock, PySymbol):
-    """Extends Function for Python codebases."""
+    """Extends Function for Python codebases.
+
+    Attributes:
+        _decorated_node: The node representing the decorated function, if any.
+    """
 
     _decorated_node: TSNode | None
 

--- a/src/codegen/sdk/python/statements/assignment_statement.py
+++ b/src/codegen/sdk/python/statements/assignment_statement.py
@@ -25,6 +25,9 @@ logger = logging.getLogger(__name__)
 class PyAssignmentStatement(AssignmentStatement["PyCodeBlock", PyAssignment]):
     """A class that represents a Python assignment statement in a codebase, such as `x = 1` or `a, b = 1, 2`.
 
+    Attributes:
+        assignment_types: A set of supported assignment types, including "assignment", "augmented_assignment", and "named_expression".
+
     This includes potentially multiple Assignments via `statement.assignments`, which represent each assignment of a value to a variable within this statement.
 
     For example, assigning to a list, or assigning multiple values to multiple variables in a single statement.

--- a/src/codegen/sdk/python/statements/break_statement.py
+++ b/src/codegen/sdk/python/statements/break_statement.py
@@ -14,7 +14,11 @@ if TYPE_CHECKING:
 
 @py_apidoc
 class PyBreakStatement(Statement["PyCodeBlock"]):
-    """An abstract representation of a python break statement."""
+    """An abstract representation of a python break statement.
+
+    Attributes:
+        statement_type: The type of the statement, set to StatementType.BREAK_STATEMENT.
+    """
 
     statement_type = StatementType.BREAK_STATEMENT
 

--- a/src/codegen/sdk/python/statements/comment.py
+++ b/src/codegen/sdk/python/statements/comment.py
@@ -9,7 +9,14 @@ from codegen.shared.decorators.docs import noapidoc, py_apidoc
 
 @py_apidoc
 class PyCommentType(StrEnum):
-    """Enum representing different types of comments."""
+    """Enum representing different types of comments.
+
+    Attributes:
+        SINGLE_LINE: Represents a single-line comment.
+        MULTI_LINE_QUOTE: Represents a multi-line comment using single quotes.
+        MULTI_LINE_DOUBLE_QUOTE: Represents a multi-line comment using double quotes.
+        UNKNOWN: Represents an unknown type of comment.
+    """
 
     SINGLE_LINE = "SINGLE_LINE"
     MULTI_LINE_QUOTE = "MULTI_LINE_QUOTE"

--- a/src/codegen/sdk/python/statements/if_block_statement.py
+++ b/src/codegen/sdk/python/statements/if_block_statement.py
@@ -21,6 +21,10 @@ Parent = TypeVar("Parent", bound="PyCodeBlock")
 @apidoc
 class PyIfBlockStatement(IfBlockStatement[Parent, "PyIfBlockStatement"], Generic[Parent]):
     """Pythons implementation of the if/elif/else statement block.
+
+    Attributes:
+        statement_type: The type of statement, set to StatementType.IF_BLOCK_STATEMENT.
+
     For example, if there is a code block like:
     if condition1:
         block1

--- a/src/codegen/sdk/python/statements/pass_statement.py
+++ b/src/codegen/sdk/python/statements/pass_statement.py
@@ -14,7 +14,11 @@ if TYPE_CHECKING:
 
 @py_apidoc
 class PyPassStatement(Statement["PyCodeBlock"]):
-    """An abstract representation of a python pass statement."""
+    """An abstract representation of a python pass statement.
+
+    Attributes:
+        statement_type: The type of statement, set to StatementType.PASS_STATEMENT.
+    """
 
     statement_type = StatementType.PASS_STATEMENT
 

--- a/src/codegen/sdk/python/statements/with_statement.py
+++ b/src/codegen/sdk/python/statements/with_statement.py
@@ -39,8 +39,10 @@ class WithStatement(Statement["PyCodeBlock"], PyHasBlock):
         # code block
 
     Attributes:
-        code_block: (PyCodeBlock) the code block of the with statement
-        clause: the expression of the with clause
+        statement_type: The type of the statement, set to StatementType.WITH_STATEMENT.
+        code_block: The code block of the with statement.
+        clause: The expression of the with clause.
+
     """
 
     statement_type = StatementType.WITH_STATEMENT

--- a/src/codegen/sdk/python/symbol_groups/comment_group.py
+++ b/src/codegen/sdk/python/symbol_groups/comment_group.py
@@ -30,6 +30,9 @@ class PyCommentGroup(CommentGroup):
     # Comment 3
     ```
     would be 3 individual comments (accessible via `symbols`), but together they form a `CommentGroup` (accessible via `self`).
+
+    Attributes:
+        _text: Actual text content of the comment
     """
 
     _text: str  # Actual text content of the comment

--- a/src/codegen/sdk/typescript/detached_symbols/jsx/element.py
+++ b/src/codegen/sdk/typescript/detached_symbols/jsx/element.py
@@ -26,7 +26,11 @@ Parent = TypeVar("Parent", bound="Editable")
 
 @ts_apidoc
 class JSXElement(Expression[Parent], HasName, Generic[Parent]):
-    """Abstract representation of TSX/JSX elements, e.g. `<MyComponent />`. This allows for many React-specific modifications, like adding props, changing the name, etc."""
+    """Abstract representation of TSX/JSX elements, e.g. `<MyComponent />`. This allows for many React-specific modifications, like adding props, changing the name, etc.
+
+    Attributes:
+        _name_node: The node representing the name of the JSX element, or None if not present.
+    """
 
     _name_node: Name | None
 

--- a/src/codegen/sdk/typescript/detached_symbols/jsx/prop.py
+++ b/src/codegen/sdk/typescript/detached_symbols/jsx/prop.py
@@ -19,7 +19,12 @@ if TYPE_CHECKING:
 
 @ts_apidoc
 class JSXProp(Expression["Function | JSXElement | JSXProp"], HasName, HasValue):
-    """Abstract representation of TSX/JSX prop, e.g <Component prop="value" />."""
+    """Abstract representation of TSX/JSX prop, e.g <Component prop="value" />.
+
+    Attributes:
+        _name_node: The name node of the JSX prop, parsed from the TSNode.
+        _expression_node: The expression node of the JSX prop, if it exists.
+    """
 
     _name_node: Name | None
     _expression_node: JSXExpression | None

--- a/src/codegen/sdk/typescript/enum_definition.py
+++ b/src/codegen/sdk/typescript/enum_definition.py
@@ -28,7 +28,13 @@ Parent = TypeVar("Parent", bound="TSHasBlock")
 
 @ts_apidoc
 class TSEnum(TSHasBlock, TSSymbol, HasAttribute[TSAttribute]):
-    """Representation of an Enum in TypeScript"""
+    """Representation of an Enum in TypeScript
+
+    Attributes:
+        symbol_type: The type of symbol, set to SymbolType.Enum.
+        body: The expression representing the body of the enum.
+        code_block: The code block associated with the enum.
+    """
 
     symbol_type = SymbolType.Enum
     body: Expression[Self]

--- a/src/codegen/sdk/typescript/export.py
+++ b/src/codegen/sdk/typescript/export.py
@@ -44,7 +44,14 @@ if TYPE_CHECKING:
 
 @ts_apidoc
 class TSExport(Export["Collection[TSExport, ExportStatement[TSExport]]"], HasValue, Chainable):
-    """Represents a single exported symbol. There is a 1:M relationship between an ExportStatement and an Export"""
+    """Represents a single exported symbol. There is a 1:M relationship between an ExportStatement and an Export.
+
+    Attributes:
+        _declared_symbol: The symbol that is declared in this export, which can be a TSSymbol, TSImport, or None.
+        _exported_symbol: The name of the exported symbol, or None if not applicable.
+        _name_node: The node representing the name of the export, or None if not applicable.
+        node_type: The type of the node, set to NodeType.EXPORT.
+    """
 
     _declared_symbol: TSSymbol | TSImport | None
     _exported_symbol: Name | None

--- a/src/codegen/sdk/typescript/expressions/conditional_type.py
+++ b/src/codegen/sdk/typescript/expressions/conditional_type.py
@@ -24,7 +24,13 @@ class TSConditionalType(Type[Parent], Generic[Parent]):
     """Conditional Type
 
     Examples:
-    typeof s
+        typeof s
+
+    Attributes:
+        left: The left-hand side type of the conditional type.
+        right: The right-hand side type of the conditional type.
+        consequence: The type to be used if the condition is true.
+        alternative: The type to be used if the condition is false.
     """
 
     left: "TSType[Self]"

--- a/src/codegen/sdk/typescript/expressions/function_type.py
+++ b/src/codegen/sdk/typescript/expressions/function_type.py
@@ -28,6 +28,8 @@ class TSFunctionType(Type[Parent], Generic[Parent]):
 
     Attributes:
         return_type: Return type of the function.
+        _parameters: Collection of parameters associated with the function type.
+        name: Placeholder for node_id generation in parameters.
 
     Examples:
         a: (a: number) => number

--- a/src/codegen/sdk/typescript/expressions/lookup_type.py
+++ b/src/codegen/sdk/typescript/expressions/lookup_type.py
@@ -23,8 +23,13 @@ Parent = TypeVar("Parent")
 @ts_apidoc
 class TSLookupType(Type[Parent], Generic[Parent]):
     """Type lookup
+
     Examples:
         a["key"]
+
+    Attributes:
+        type: The type of the TypeScript object being looked up.
+        lookup: The expression used for the lookup operation.
     """
 
     type: "TSType[Self]"

--- a/src/codegen/sdk/typescript/expressions/query_type.py
+++ b/src/codegen/sdk/typescript/expressions/query_type.py
@@ -23,8 +23,9 @@ Parent = TypeVar("Parent")
 class TSQueryType(Type[Parent], Generic[Parent]):
     """Type query
 
-    Examples:
-    typeof s
+
+    Attributes:
+        query: The TypeScript type query, e.g. typeof s
     """
 
     query: "TSType[Self]"

--- a/src/codegen/sdk/typescript/expressions/readonly_type.py
+++ b/src/codegen/sdk/typescript/expressions/readonly_type.py
@@ -25,6 +25,9 @@ class TSReadonlyType(Type[Parent], Generic[Parent]):
 
     Examples:
     readonly s
+
+    Attributes:
+        type: The underlying TypeScript type associated with this readonly type.
     """
 
     type: "TSType[Self]"

--- a/src/codegen/sdk/typescript/file.py
+++ b/src/codegen/sdk/typescript/file.py
@@ -33,7 +33,12 @@ if TYPE_CHECKING:
 
 @ts_apidoc
 class TSFile(SourceFile[TSImport, TSFunction, TSClass, TSAssignment, TSInterface, TSCodeBlock], TSHasBlock, Exportable):
-    """Extends the SourceFile class to provide TypeScript-specific functionality."""
+    """Extends the SourceFile class to provide TypeScript-specific functionality.
+
+    Attributes:
+        programming_language: The programming language of the file. Set to ProgrammingLanguage.TYPESCRIPT.
+        ts_config: The ts_config file nearest to this file.
+    """
 
     programming_language = ProgrammingLanguage.TYPESCRIPT
     ts_config: TSConfig | None = None

--- a/src/codegen/sdk/typescript/namespace.py
+++ b/src/codegen/sdk/typescript/namespace.py
@@ -29,7 +29,12 @@ if TYPE_CHECKING:
 
 @ts_apidoc
 class TSNamespace(TSSymbol, TSHasBlock, HasName):
-    """Representation of a namespace module in TypeScript"""
+    """Representation of a namespace module in TypeScript.
+
+    Attributes:
+        symbol_type: The type of symbol, set to SymbolType.Namespace.
+        code_block: The code block associated with this namespace.
+    """
 
     symbol_type = SymbolType.Namespace
     code_block: TSCodeBlock

--- a/src/codegen/sdk/typescript/statements/assignment_statement.py
+++ b/src/codegen/sdk/typescript/statements/assignment_statement.py
@@ -26,9 +26,10 @@ logger = logging.getLogger(__name__)
 class TSAssignmentStatement(AssignmentStatement["TSCodeBlock", TSAssignment]):
     """A class that represents a TypeScript assignment statement in a codebase, such as `const x = 1` or `const { a: b } = myFunc()`.
 
-    This includes potentially multiple Assignments via `statement.assignments`, which represent each assignment of a value to a variable within this statement.
-
-    For example, assigning to a destructured object, or assigning multiple values to multiple variables in a single statement.
+    Attributes:
+        assignment_types: A set of supported assignment node types, including
+            assignment_expression, augmented_assignment_expression,
+            variable_declarator, public_field_definition, and property_signature.
     """
 
     assignment_types = {"assignment_expression", "augmented_assignment_expression", "variable_declarator", "public_field_definition", "property_signature"}

--- a/src/codegen/sdk/typescript/statements/if_block_statement.py
+++ b/src/codegen/sdk/typescript/statements/if_block_statement.py
@@ -25,15 +25,10 @@ Parent = TypeVar("Parent", bound="TSCodeBlock")
 @apidoc
 class TSIfBlockStatement(IfBlockStatement[Parent, "TSIfBlockStatement"], Generic[Parent]):
     """Typescript implementation of the if/elif/else statement block.
-    For example, if there is a code block like:
-    if (condition1) {
-        block1
-    } else if (condition2) {
-        block2
-    } else {
-        block3
-    }
-    This class represents the entire block, including the conditions and nested code blocks.
+
+    Attributes:
+        statement_type: The type of statement, set to StatementType.IF_BLOCK_STATEMENT.
+        _else_clause_node: The TreeSitter node representing the else clause, if any.
     """
 
     statement_type = StatementType.IF_BLOCK_STATEMENT

--- a/src/codegen/sdk/typescript/statements/labeled_statement.py
+++ b/src/codegen/sdk/typescript/statements/labeled_statement.py
@@ -36,6 +36,10 @@ class TSLabeledStatement(Statement[Parent], HasName, Generic[Parent]):
     ```
     emptyStatement: { pass }
     ```
+
+    Attributes:
+        statement_type: The type of the statement, set to StatementType.LABELED_STATEMENT.
+        body: The body of the labeled statement, which can be an expression or None.
     """
 
     statement_type = StatementType.LABELED_STATEMENT

--- a/src/codegen/sdk/typescript/ts_config.py
+++ b/src/codegen/sdk/typescript/ts_config.py
@@ -19,7 +19,30 @@ logger = logging.getLogger(__name__)
 
 @ts_apidoc
 class TSConfig:
-    """TypeScript configuration file specified in tsconfig.json, used for import resolution and computing dependencies."""
+    """TypeScript configuration file specified in tsconfig.json, used for import resolution and computing dependencies.
+
+    Attributes:
+        config_file: The configuration file object representing the tsconfig.json file.
+        config_parser: The parser used to interpret the TypeScript configuration.
+        config: A dictionary containing the parsed configuration settings.
+        _base_config: The base TSConfig object that this config extends, if any.
+        _base_url: The base URL for module resolution, if specified.
+        _out_dir: The output directory for compiled files, if specified.
+        _root_dir: The root directory for input files, if specified.
+        _root_dirs: A list of root directories treated as one virtual directory.
+        _paths: A dictionary mapping module path patterns to target paths.
+        _references: A list of references to other projects or files.
+        _self_base_url: The base URL specific to this configuration.
+        _self_out_dir: The output directory specific to this configuration.
+        _self_root_dir: The root directory specific to this configuration.
+        _self_root_dirs: A list of root directories specific to this configuration.
+        _self_paths: A dictionary of path mappings specific to this configuration.
+        _self_references: A list of references specific to this configuration.
+        _computed_path_import_aliases: A flag indicating if path import aliases have been computed.
+        _path_import_aliases: A dictionary of formatted path import aliases.
+        _reference_import_aliases: A dictionary of formatted reference import aliases.
+        _import_optimization_enabled: A flag indicating if import optimization is enabled.
+    """
 
     config_file: File
     config_parser: "TSConfigParser"

--- a/src/codegen/sdk/typescript/type_alias.py
+++ b/src/codegen/sdk/typescript/type_alias.py
@@ -12,7 +12,11 @@ from codegen.shared.decorators.docs import noapidoc, ts_apidoc
 
 @ts_apidoc
 class TSTypeAlias(TypeAlias[TSCodeBlock, TSAttribute], TSSymbol, TSHasBlock):
-    """Representation of an Interface in TypeScript"""
+    """Representation of an Interface in TypeScript.
+
+    Attributes:
+        symbol_type: The type of symbol, set to SymbolType.Type.
+    """
 
     symbol_type = SymbolType.Type
 

--- a/tests/unit/codegen/sdk/code_generation/test_api_doc_generation.py
+++ b/tests/unit/codegen/sdk/code_generation/test_api_doc_generation.py
@@ -47,7 +47,7 @@ def test_api_doc_generation_sanity(codebase, language: ProgrammingLanguage) -> N
     # assert "InviteFactoryCreateParams" in docs # Canonicals aren't in docs
 
 
-@pytest.mark.timeout(160)
+@pytest.mark.timeout(300)
 @pytest.mark.xdist_group("codegen")
 def test_mdx_api_doc_generation_sanity(codebase) -> None:
     docs_json = generate_docs_json(codebase, "HEAD", raise_on_missing_docstring=True)

--- a/tests/unit/codegen/sdk/code_generation/test_api_doc_generation.py
+++ b/tests/unit/codegen/sdk/code_generation/test_api_doc_generation.py
@@ -40,7 +40,7 @@ def test_api_doc_generation_sanity(codebase, language: ProgrammingLanguage) -> N
     other_lang = "TS" if language == ProgrammingLanguage.PYTHON else "Py"
     # =====[ Python ]=====
     docs = get_codegen_sdk_docs(language=language, codebase=codebase)
-    assert count_tokens(docs) < 55000
+    assert count_tokens(docs) < 70000
     assert f"{lang}Function" in docs
     assert f"{lang}Class" in docs
     assert f"{other_lang}Function" not in docs
@@ -50,7 +50,7 @@ def test_api_doc_generation_sanity(codebase, language: ProgrammingLanguage) -> N
 @pytest.mark.timeout(160)
 @pytest.mark.xdist_group("codegen")
 def test_mdx_api_doc_generation_sanity(codebase) -> None:
-    docs_json = generate_docs_json(codebase, "HEAD")
+    docs_json = generate_docs_json(codebase, "HEAD", raise_on_missing_docstring=True)
 
     assert len(docs_json.classes) > 0
 


### PR DESCRIPTION
# Motivation
Many attributes have missing docstrings

# Content
Adds missing docstrings to attributes of classes decorated with one of `apidoc`, `py_apidoc` or `ts_apidoc`.

# Please check the following before marking your PR as ready for review

- [x] I have added tests for my changes
- [x] I have updated the documentation or added new documentation as needed
