### PR TITLE
CG-10630: Doc Generation Upgrade

### DIFF
--- a/docs/api-reference/core/ImportType.mdx
+++ b/docs/api-reference/core/ImportType.mdx
@@ -1,0 +1,44 @@
+---
+title: "ImportType"
+sidebarTitle: "ImportType"
+icon: ""
+description: "Import types for each import object. Determines what the import resolves to, and what symbols are imported."
+---
+import {Parameter} from '/snippets/Parameter.mdx';
+import {ParameterWrapper} from '/snippets/ParameterWrapper.mdx';
+import {Return} from '/snippets/Return.mdx';
+import {HorizontalDivider} from '/snippets/HorizontalDivider.mdx';
+import {GithubLinkNote} from '/snippets/GithubLinkNote.mdx';
+import {Attribute} from '/snippets/Attribute.mdx';
+
+<GithubLinkNote link="https://github.com/codegen-sh/codegen-sdk/blob/develop/src/codegen/sdk/enums.py#L55-L79" />
+
+
+## Attributes
+<HorizontalDivider />
+### <span className="text-primary">DEFAULT_EXPORT</span>
+<HorizontalDivider light={true} />
+<Attribute type={ <span></span> } description="Imports all default exports. Resolves to the file." />
+
+### <span className="text-primary">MODULE</span>
+<HorizontalDivider light={true} />
+<Attribute type={ <span></span> } description="Imports the module, not doesn't actually allow access to any of the exports" />
+
+### <span className="text-primary">NAMED_EXPORT</span>
+<HorizontalDivider light={true} />
+<Attribute type={ <span></span> } description="Imports a named export. Resolves to the symbol export." />
+
+### <span className="text-primary">SIDE_EFFECT</span>
+<HorizontalDivider light={true} />
+<Attribute type={ <span></span> } description="Imports the module, not doesn't actually allow access to any of the exports" />
+
+### <span className="text-primary">UNKNOWN</span>
+<HorizontalDivider light={true} />
+<Attribute type={ <span></span> } description="Unknown import type." />
+
+### <span className="text-primary">WILDCARD</span>
+<HorizontalDivider light={true} />
+<Attribute type={ <span></span> } description="Imports all named exports, and default exports as `default`. Resolves to the file." />
+
+
+

--- a/ruff.toml
+++ b/ruff.toml
@@ -137,6 +137,7 @@ extend-generics = [
   "codegen.sdk.core.symbol_groups.multi_line_collection.MultiLineCollection",
   "codegen.sdk.core.symbol_groups.tuple.Tuple",
   "codegen.sdk.core.type_alias.TypeAlias",
+  "codegen.sdk.enums.ImportType",
   "codegen.sdk.python.statements.if_block_statement.PyIfBlockStatement",
   "codegen.sdk.python.statements.with_statement.WithStatement",
   "codegen.sdk.typescript.statements.block_statement.TSBlockStatement",

--- a/src/codegen/sdk/code_generation/doc_utils/generate_docs_json.py
+++ b/src/codegen/sdk/code_generation/doc_utils/generate_docs_json.py
@@ -1,10 +1,8 @@
-from typing import Any
-
 from tqdm import tqdm
 
 from codegen.sdk.code_generation.doc_utils.parse_docstring import parse_docstring
 from codegen.sdk.code_generation.doc_utils.schemas import ClassDoc, GSDocs, MethodDoc
-from codegen.sdk.code_generation.doc_utils.utils import create_path, get_langauge, get_type, get_type_str, has_documentation, is_settter, replace_multiple_types
+from codegen.sdk.code_generation.doc_utils.utils import create_path, extract_class_description, get_langauge, get_type, get_type_str, has_documentation, is_settter, replace_multiple_types
 from codegen.sdk.core.class_definition import Class
 from codegen.sdk.core.codebase import Codebase
 from codegen.sdk.core.placeholder.placeholder_type import TypePlaceholder
@@ -27,7 +25,7 @@ ATTRIBUTES_TO_IGNORE = [
 ]
 
 
-def generate_docs_json(codebase: Codebase, head_commit: str, raise_on_missing_docstring: bool = False) -> dict[str, dict[str, Any]]:
+def generate_docs_json(codebase: Codebase, head_commit: str, raise_on_missing_docstring: bool = False) -> GSDocs:
     """Update documentation table for classes, methods and attributes in the codebase.
 
     Args:
@@ -46,7 +44,7 @@ def generate_docs_json(codebase: Codebase, head_commit: str, raise_on_missing_do
 
         cls_doc = ClassDoc(
             title=cls.name,
-            description=description,
+            description=extract_class_description(description),
             content=" ",
             path=create_path(cls),
             inherits_from=parent_classes,

--- a/src/codegen/sdk/enums.py
+++ b/src/codegen/sdk/enums.py
@@ -2,6 +2,7 @@ from enum import IntEnum, StrEnum, auto
 from typing import NamedTuple
 
 from codegen.sdk.core.dataclasses.usage import Usage
+from codegen.shared.decorators.docs import apidoc
 
 
 class NodeType(IntEnum):
@@ -51,8 +52,18 @@ class SymbolType(IntEnum):
     Namespace = auto()
 
 
+@apidoc
 class ImportType(IntEnum):
-    """Import types for each import object. Determines what the import resolves to, and what symbols are imported."""
+    """Import types for each import object. Determines what the import resolves to, and what symbols are imported.
+
+    Attributes:
+        DEFAULT_EXPORT: Imports all default exports. Resolves to the file.
+        NAMED_EXPORT: Imports a named export. Resolves to the symbol export.
+        WILDCARD: Imports all named exports, and default exports as `default`. Resolves to the file.
+        MODULE: Imports the module, not doesn't actually allow access to any of the exports
+        SIDE_EFFECT: Imports the module, not doesn't actually allow access to any of the exports
+        UNKNOWN: Unknown import type.
+    """
 
     # Imports all default exports. Resolves to the file.
     DEFAULT_EXPORT = auto()

--- a/src/codegen/shared/compilation/function_imports.py
+++ b/src/codegen/shared/compilation/function_imports.py
@@ -108,6 +108,7 @@ from codegen.sdk.core.symbol_groups.list import List
 from codegen.sdk.core.symbol_groups.multi_line_collection import MultiLineCollection
 from codegen.sdk.core.symbol_groups.tuple import Tuple
 from codegen.sdk.core.type_alias import TypeAlias
+from codegen.sdk.enums import ImportType
 from codegen.sdk.python.assignment import PyAssignment
 from codegen.sdk.python.class_definition import PyClass
 from codegen.sdk.python.detached_symbols.code_block import PyCodeBlock


### PR DESCRIPTION
# Motivation
- Attribute section should not show up in class docstrings
- Fixed Incorrect parameter and return types in language specific symbols
    - PySymbol.file now shows `PyFile` type (instead of `SourceFile`)
- Added missing page for ImportType

# Content
- added code that removes attributes section from class docstrings
- modified logic to properly resolve parameter and return types in language specific symbols
- added docstring for ImportType

# Testing
existing test were used.

# Please check the following before marking your PR as ready for review

- [x] I have added tests for my changes
- [x] I have updated the documentation or added new documentation as needed
