### PR TITLE
ci: don't report coverage data as json

### DIFF
--- a/.github/actions/run_ats/action.yml
+++ b/.github/actions/run_ats/action.yml
@@ -21,8 +21,7 @@ inputs:
     default: ''
   codecov_flags:
     description: 'Flags for codecov upload'
-    required: false
-    default: 'smart-tests'
+    required: true
 
 runs:
   using: "composite"

--- a/.github/actions/run_ats/action.yml
+++ b/.github/actions/run_ats/action.yml
@@ -54,7 +54,6 @@ runs:
           -vv \
           --cov \
           --cov-append \
-          --cov-report=xml \
           ${{ inputs.collect_args }}
 
     - uses: ./.github/actions/report

--- a/.github/actions/run_ats/action.yml
+++ b/.github/actions/run_ats/action.yml
@@ -43,7 +43,6 @@ runs:
     - name: Run tests
       shell: bash
       run: |
-        echo "pwd: $(pwd)" # FIXME: for debugging
         TESTS_TO_RUN=$(cat codecov_ats/tests_to_run.txt)
         if [ -z "$TESTS_TO_RUN" ]; then
           echo "No tests to run, skipping..."

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -17,7 +17,7 @@ component_management:
         - type: patch
           target: 50 # Language specific featues must be 100% covered
       flags:
-        - smart-tests
+        - unit-tests
     - component_id: codegen-sdk-typescript
       name: codegen-sdk-typescript
       paths:
@@ -27,10 +27,14 @@ component_management:
           threshold: 0 # Shouldn't remove coverage
         - type: patch
           target: 50 # Language specific featues must be 100% covered
+      flags:
+        - unit-tests
     - component_id: codegen-sdk-core
       name: codegen-sdk-core
       paths:
         - src/codegen/sdk/**
+      flags:
+        - unit-tests
 
 flag_management:
   default_rules:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-latest-16
+    runs-on: ubuntu-latest-8
     steps:
       - uses: actions/checkout@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ pythonpath = "."
 norecursedirs = "repos expected"
 # addopts = -v --cov=app --cov-report=term
 
-addopts = "--dist=loadgroup --junitxml=build/test-results/test/TEST.xml --strict-config --import-mode=importlib --cov-context=test --cov-report=json --cov-config=pyproject.toml -p no:doctest"
+addopts = "--dist=loadgroup --junitxml=build/test-results/test/TEST.xml --strict-config --import-mode=importlib --cov-context=test --cov-config=pyproject.toml -p no:doctest"
 filterwarnings = """
     ignore::DeprecationWarning:botocore.*:
     ignore::DeprecationWarning:sqlalchemy.*:

--- a/src/codegen/sdk/core/import_resolution.py
+++ b/src/codegen/sdk/core/import_resolution.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Generic, Literal, Self, TypeVar, override
+from typing import TYPE_CHECKING, ClassVar, Generic, Literal, Self, TypeVar, override
 
 from codegen.sdk.codebase.resolution_stack import ResolutionStack
 from codegen.sdk.codebase.transactions import TransactionPriority
@@ -76,7 +76,7 @@ class Import(Usable[ImportStatement], Chainable, Generic[TSourceFile], HasAttrib
     module: Editable | None
     symbol_name: Editable | None
     alias: Editable | None
-    node_type: Literal[NodeType.IMPORT] = NodeType.IMPORT
+    node_type: ClassVar[Literal[NodeType.IMPORT]] = NodeType.IMPORT
     import_type: ImportType
     import_statement: ImportStatement
 


### PR DESCRIPTION
# Contents
- Remove refrences to old smart-tests flag
- Don't report coverage to JSON or XML by default, let the codecov CLI handle that
- Random SDK change to test CI
# Results
- Brings down full run from 11m to 6m
