### PR TITLE
fix: Disable uv cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         uses: astral-sh/setup-uv@v5.2
         id: setup-uv
         with:
-          enable-cache: true
+          enable-cache: false
           prune-cache: false
           python-version: 3.${{ matrix.python }}
           version: '0.5.24'


### PR DESCRIPTION
# Motivation
Broken release workflow due to uv cache: https://github.com/codegen-sh/codegen-sdk/actions/runs/13190198301/job/36821675815

# Content
Disables uv setup cache

# Testing

<!-- How was the change tested? -->

# Please check the following before marking your PR as ready for review

- [ ] I have added tests for my changes
- [ ] I have updated the documentation or added new documentation as needed
