### PR TITLE
ops: disable auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   release:
+    if: false # TODO(CG-10755): merge this with release.yml
     name: Release
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
trigger isn't working b/c github doesn't let you chain from bot to bot to prevent loops

need to merge the workflows
https://linear.app/codegen-sh/issue/CG-10755/merge-releaseyml-with-auto-releaseyml