### PR TITLE
ci: use `ubuntu-22` instead

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         os: [
           ubuntu-latest,
-          ubuntu-24.04-arm, # https://github.com/actions/partner-runner-images/issues/37
+          ubuntu-22.04-arm, # https://github.com/actions/partner-runner-images/issues/37 https://github.com/orgs/community/discussions/148648#discussioncomment-12099554
           macos-latest,
           macos-14-large
         ]


### PR DESCRIPTION
hopefully this addresses the `actions/checkout` issue 
https://github.com/orgs/community/discussions/148648#discussioncomment-11866202