### PR TITLE
Fixing links to examples in tutorials

### DIFF
--- a/docs/tutorials/fixing-import-loops-in-pytorch.mdx
+++ b/docs/tutorials/fixing-import-loops-in-pytorch.mdx
@@ -23,7 +23,7 @@ Import loops occur when two or more Python modules depend on each other, creatin
 In this tutorial, we'll explore how to identify and fix problematic import cycles using Codegen.
 
 <Info>
-You can find the complete example code in our [examples repository](https://github.com/codegen-sh/codegen-examples/tree/main/examples/removing_import_loops_in_pytorch).
+You can find the complete example code in our [examples repository](https://github.com/codegen-sh/codegen-sdk/tree/93f0d4cd7740e3e01ee7ecfd69fd3259b8ebf783/codegen-examples/examples/removing_import_loops_in_pytorch).
 </Info>
 
 ## Overview

--- a/docs/tutorials/flask-to-fastapi.mdx
+++ b/docs/tutorials/flask-to-fastapi.mdx
@@ -7,7 +7,7 @@ iconType: "solid"
 
 Migrating from [Flask](https://flask.palletsprojects.com/) to [FastAPI](https://fastapi.tiangolo.com/) involves several key changes to your codebase. This guide will walk you through using Codegen to automate this migration, handling imports, route decorators, static files, and template rendering.
 
-You can find the complete example code in our [examples repository](https://github.com/codegen-sh/codegen-examples/tree/7b978091c3153b687c32928fe10f05425e22f6a5/examples/flask_to_fastapi_migration)
+You can find the complete example code in our [examples repository](https://github.com/codegen-sh/codegen-sdk/tree/93f0d4cd7740e3e01ee7ecfd69fd3259b8ebf783/codegen-examples/examples/flask_to_fastapi_migration)
 
 ## Overview
 
@@ -183,8 +183,8 @@ def list_users(request: Request):
 You can run the complete migration using our example script:
 
 ```bash
-git clone https://github.com/codegen-sh/codegen-examples.git
-cd codegen-examples/flask_to_fastapi_migration
+git clone https://github.com/codegen-sh/codegen-sdk.git
+cd codegen-examples/examples/flask_to_fastapi_migration
 python run.py
 ```
 

--- a/docs/tutorials/python2-to-python3.mdx
+++ b/docs/tutorials/python2-to-python3.mdx
@@ -9,7 +9,7 @@ iconType: "solid"
 Migrating from Python 2 to Python 3 involves several syntax and API changes. This guide will walk you through using Codegen to automate this migration, handling print statements, string handling, iterators, and more.
 
 <Info>
-You can find the complete example code in our [examples repository](https://github.com/codegen-sh/codegen-examples/tree/7b978091c3153b687c32928fe10f05425e22f6a5/examples/python2_to_python3).
+You can find the complete example code in our [examples repository](https://github.com/codegen-sh/codegen-sdk/tree/93f0d4cd7740e3e01ee7ecfd69fd3259b8ebf783/codegen-examples/examples/python2_to_python3).
 </Info>
 
 ## Overview
@@ -222,8 +222,8 @@ class MyIterator:
 You can run the complete migration using our example script:
 
 ```bash
-git clone https://github.com/codegen-sh/codegen-examples.git
-cd codegen-examples/python2_to_python3
+git clone https://github.com/codegen-sh/codegen-sdk.git
+cd codegen-examples/examples/python2_to_python3
 python run.py
 ```
 

--- a/docs/tutorials/sqlalchemy-1.6-to-2.0.mdx
+++ b/docs/tutorials/sqlalchemy-1.6-to-2.0.mdx
@@ -9,7 +9,7 @@ iconType: "solid"
 Migrating from [SQLAlchemy](https://www.sqlalchemy.org/) 1.6 to 2.0 involves several API changes to support the new 2.0-style query interface. This guide will walk you through using Codegen to automate this migration, handling query syntax, session usage, and ORM patterns.
 
 <Info>
-You can find the complete example code in our [examples repository](https://github.com/codegen-sh/codegen-examples/tree/7b978091c3153b687c32928fe10f05425e22f6a5/examples/sqlalchemy_1.6_to_2.0).
+You can find the complete example code in our [examples repository](https://github.com/codegen-sh/codegen-sdk/tree/93f0d4cd7740e3e01ee7ecfd69fd3259b8ebf783/codegen-examples/examples/sqlalchemy_1.6_to_2.0).
 </Info>
 
 ## Overview

--- a/docs/tutorials/training-data.mdx
+++ b/docs/tutorials/training-data.mdx
@@ -8,7 +8,7 @@ iconType: "solid"
 
 This guide demonstrates how to use Codegen to generate high-quality training data for large language models (LLMs) by extracting function implementations along with their dependencies and usages. This approach is similar to [word2vec](https://www.tensorflow.org/text/tutorials/word2vec) or [node2vec](https://snap.stanford.edu/node2vec/) - given the context of a function, learn to predict the function's implementation.
 
-<Info>View the full code in our [examples repository](https://github.com/codegen-sh/codegen-examples/tree/7b978091c3153b687c32928fe10f05425e22f6a5/examples/generate_training_data)</Info>
+<Info>View the full code in our [examples repository](https://github.com/codegen-sh/codegen-sdk/tree/93f0d4cd7740e3e01ee7ecfd69fd3259b8ebf783/codegen-examples/examples/generate_training_data)</Info>
 
 <Tip>This example works with both Python and Typescript repositories without modification</Tip>
 

--- a/docs/tutorials/unittest-to-pytest.mdx
+++ b/docs/tutorials/unittest-to-pytest.mdx
@@ -9,7 +9,7 @@ iconType: "solid"
 Migrating from [unittest](https://docs.python.org/3/library/unittest.html) to [pytest](https://docs.pytest.org/) involves converting test classes and assertions to pytest's more modern and concise style. This guide will walk you through using Codegen to automate this migration.
 
 <Info>
-You can find the complete example code in our [examples repository](https://github.com/codegen-sh/codegen-examples/tree/7b978091c3153b687c32928fe10f05425e22f6a5/examples/unittest_to_pytest).
+You can find the complete example code in our [examples repository](https://github.com/codegen-sh/codegen-sdk/tree/93f0d4cd7740e3e01ee7ecfd69fd3259b8ebf783/codegen-examples/examples/unittest_to_pytest).
 </Info>
 
 ## Overview


### PR DESCRIPTION
Some of the tutorials still link to the deprecated `codegen-examples` repo. This PR makes all tutorials link to the `codegen-examples` in `codegen-sdk`.