### PR TITLE
nit: do not raise on codebase parse

### DIFF
--- a/src/codegen/runner/sandbox/server.py
+++ b/src/codegen/runner/sandbox/server.py
@@ -54,7 +54,6 @@ async def lifespan(server: FastAPI):
     except Exception:
         logger.exception("Failed to build graph during warmup")
         server_info.warmup_state = WarmupState.FAILED
-        raise
 
     logger.info("Sandbox fastapi server is ready to accept requests")
     yield


### PR DESCRIPTION
# Motivation

This is to allow the server to keep running even after failure to parse such that modal cleanup_runner cron job can detect failure and alert team on slack

# Content

<!-- Please include a summary of the change -->

# Testing

<!-- How was the change tested? -->

# Please check the following before marking your PR as ready for review

- [ ] I have added tests for my changes
- [ ] I have updated the documentation or added new documentation as needed
