### PR TITLE
Add git-based codebase language detection

### DIFF
--- a/src/codegen/git/utils/language.py
+++ b/src/codegen/git/utils/language.py
@@ -120,10 +120,6 @@ def _determine_language_by_git_file_count(folder_path: str) -> ProgrammingLangua
         if file_path.is_dir() or file_path.name.startswith("."):
             continue
 
-        # Skip common directories to ignore
-        if any(ignore in str(file_path) for ignore in [".git", "node_modules", "__pycache__", "venv", ".env"]):
-            continue
-
         # Count files for each language based on extensions
         for language, exts in EXTENSIONS.items():
             if file_path.suffix in exts:

--- a/src/codegen/git/utils/language.py
+++ b/src/codegen/git/utils/language.py
@@ -2,16 +2,17 @@ from collections import Counter
 from pathlib import Path
 from typing import Literal
 
+from codegen.git.utils.file_utils import split_git_path
 from codegen.shared.enums.programming_language import ProgrammingLanguage
 
 
-def determine_project_language(folder_path: str, strategy: Literal["most_common", "package_json"] = "package_json") -> ProgrammingLanguage:
+def determine_project_language(folder_path: str, strategy: Literal["most_common", "git_most_common", "package_json"] = "git_most_common") -> ProgrammingLanguage:
     """Determines the primary programming language of a project.
 
     Args:
         folder_path (str): Path to the folder to analyze
-        strategy (Literal["most_common", "package_json"]): Strategy to use for determining language.
-            "most_common" analyzes file extensions, "package_json" checks for package.json presence.
+        strategy (Literal["most_common", "git_most_common", "package_json"]): Strategy to use for determining language.
+            "most_common" analyzes file extensions, "git_most_common" analyzes files in the git repo, "package_json" checks for package.json presence.
 
     Returns:
         ProgrammingLanguage: The determined programming language
@@ -19,25 +20,13 @@ def determine_project_language(folder_path: str, strategy: Literal["most_common"
     # TODO: Create a new strategy that follows gitignore
     if strategy == "most_common":
         return _determine_language_by_file_count(folder_path)
+    elif strategy == "git_most_common":
+        return _determine_language_by_git_file_count(folder_path)
     elif strategy == "package_json":
         return _determine_language_by_package_json(folder_path)
-
-
-def _determine_language_by_package_json(folder_path: str) -> ProgrammingLanguage:
-    """Determines project language by checking for presence of package.json.
-    Faster but less accurate than file count strategy.
-
-    Args:
-        folder_path (str): Path to the folder to analyze
-
-    Returns:
-        ProgrammingLanguage: TYPESCRIPT if package.json exists, otherwise PYTHON
-    """
-    package_json_path = Path(folder_path) / "package.json"
-    if package_json_path.exists():
-        return ProgrammingLanguage.TYPESCRIPT
     else:
-        return ProgrammingLanguage.PYTHON
+        msg = f"Invalid strategy: {strategy}"
+        raise ValueError(msg)
 
 
 def _determine_language_by_file_count(folder_path: str) -> ProgrammingLanguage:
@@ -87,3 +76,79 @@ def _determine_language_by_file_count(folder_path: str) -> ProgrammingLanguage:
 
     # Return the language with the highest count
     return language_counts.most_common(1)[0][0]
+
+
+def _determine_language_by_git_file_count(folder_path: str) -> ProgrammingLanguage:
+    """Analyzes a git repo to determine the primary programming language based on file extensions.
+    Returns the language with the most matching files.
+
+    Args:
+        folder_path (str): Path to the git repo to analyze
+
+    Returns:
+        ProgrammingLanguage: The dominant programming language, or UNSUPPORTED if no matching files found
+    """
+    from codegen.git.repo_operator.local_repo_operator import LocalRepoOperator
+    from codegen.git.schemas.repo_config import RepoConfig
+    from codegen.sdk.python import PyFile
+    from codegen.sdk.typescript.file import TSFile
+
+    EXTENSIONS = {
+        ProgrammingLanguage.PYTHON: PyFile.get_extensions(),
+        ProgrammingLanguage.TYPESCRIPT: TSFile.get_extensions(),
+    }
+
+    folder = Path(folder_path)
+    if not folder.exists() or not folder.is_dir():
+        msg = f"Invalid folder path: {folder_path}"
+        raise ValueError(msg)
+
+    # Initialize counters for each language
+    language_counts = Counter()
+
+    # Initiate LocalRepoOperator
+    git_root, base_path = split_git_path(folder_path)
+    repo_config = RepoConfig.from_repo_path(repo_path=git_root)
+    repo_operator = LocalRepoOperator(repo_config=repo_config)
+
+    # Walk through the directory
+    for rel_path, _ in repo_operator.iter_files(subdirs=[base_path] if base_path else None):
+        # Convert to Path object
+        file_path = Path(git_root) / Path(rel_path)
+
+        # Skip directories and hidden files
+        if file_path.is_dir() or file_path.name.startswith("."):
+            continue
+
+        # Skip common directories to ignore
+        if any(ignore in str(file_path) for ignore in [".git", "node_modules", "__pycache__", "venv", ".env"]):
+            continue
+
+        # Count files for each language based on extensions
+        for language, exts in EXTENSIONS.items():
+            if file_path.suffix in exts:
+                language_counts[language] += 1
+
+    # If no files found, return None
+    if not language_counts:
+        return ProgrammingLanguage.UNSUPPORTED
+
+    # Return the language with the highest count
+    return language_counts.most_common(1)[0][0]
+
+
+def _determine_language_by_package_json(folder_path: str) -> ProgrammingLanguage:
+    """Determines project language by checking for presence of package.json.
+    Faster but less accurate than file count strategy.
+
+    Args:
+        folder_path (str): Path to the folder to analyze
+
+    Returns:
+        ProgrammingLanguage: TYPESCRIPT if package.json exists, otherwise PYTHON
+    """
+    package_json_path = Path(folder_path) / "package.json"
+    if package_json_path.exists():
+        return ProgrammingLanguage.TYPESCRIPT
+    else:
+        return ProgrammingLanguage.PYTHON


### PR DESCRIPTION
# Motivation

Legacy `most_common` strategy is slow and unnecessarily scans through `node_modules`, current `package_json` strategy is flakey. The new `git_most_common` strategy aims to address both of these issues.

# Content

Adds `git_most_common` strategy to `determine_project_language`
![image](https://github.com/user-attachments/assets/39ba0bc9-43bf-4039-a660-75da2252aa72)

# Please check the following before marking your PR as ready for review

- [ ] I have added tests for my changes
- [ ] I have updated the documentation or added new documentation as needed
