### PR TITLE
LLM Class -> Switch Model Providers and Extend Other Models Easier

### DIFF
--- a/src/codegen/extensions/langchain/.env.template
+++ b/src/codegen/extensions/langchain/.env.template
@@ -1,0 +1,8 @@
+# API Keys for LLM providers
+# You must provide the API key for the provider you want to use
+
+# Required for using Anthropic models (e.g., claude-3-*)
+ANTHROPIC_API_KEY=your_anthropic_key_here
+
+# Required for using OpenAI models (e.g., gpt-4*)
+OPENAI_API_KEY=your_openai_key_here

--- a/src/codegen/extensions/langchain/agent.py
+++ b/src/codegen/extensions/langchain/agent.py
@@ -4,7 +4,6 @@ from langchain.agents import AgentExecutor, create_tool_calling_agent
 from langchain.agents.openai_functions_agent.base import OpenAIFunctionsAgent
 from langchain.hub import pull
 from langchain.tools import BaseTool
-from langchain_anthropic import ChatAnthropic
 from langchain_core.chat_history import InMemoryChatMessageHistory
 from langchain_core.messages import BaseMessage
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
@@ -13,6 +12,7 @@ from langchain_openai import ChatOpenAI
 
 from codegen.sdk.core.codebase import Codebase
 
+from .llm import LLM
 from .tools import (
     CreateFileTool,
     DeleteFileTool,
@@ -30,6 +30,7 @@ from .tools import (
 
 def create_codebase_agent(
     codebase: Codebase,
+    model_provider: str = "anthropic",
     model_name: str = "claude-3-5-sonnet-latest",
     temperature: float = 0,
     verbose: bool = True,
@@ -46,16 +47,9 @@ def create_codebase_agent(
     Returns:
         Initialized agent with message history
     """
-    # Initialize language model
-    # llm = ChatOpenAI(
-    #     model_name=model_name,
-    #     temperature=temperature,
-    # )
+    llm = LLM(model_provider=model_provider, model_name=model_name, temperature=temperature)
 
-    llm = ChatAnthropic(
-        model="claude-3-5-sonnet-latest",
-        temperature=temperature,
-    )
+    # Create a tool calling agent
 
     # Get all codebase tools
     tools = [
@@ -135,12 +129,6 @@ def create_codebase_agent(
         ]
     )
 
-    # Create the agent
-    # agent = OpenAIFunctionsAgent(
-    #     llm=llm,
-    #     tools=tools,
-    #     prompt=prompt,
-    # )
     agent = create_tool_calling_agent(
         llm=llm,
         tools=tools,

--- a/src/codegen/extensions/langchain/llm.py
+++ b/src/codegen/extensions/langchain/llm.py
@@ -1,0 +1,98 @@
+"""LLM implementation supporting both OpenAI and Anthropic models."""
+
+import os
+from typing import Any, Literal, Optional
+
+from langchain_anthropic import ChatAnthropic
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import BaseMessage
+from langchain_core.outputs import ChatResult
+from langchain_openai import ChatOpenAI
+from pydantic import Field
+
+
+class LLM(BaseChatModel):
+    """A unified chat model that supports both OpenAI and Anthropic."""
+
+    model_provider: Literal["anthropic", "openai"] = Field(default="anthropic", description="The model provider to use.")
+
+    model_name: str = Field(default="claude-3-5-sonnet-latest", description="Name of the model to use.")
+
+    temperature: float = Field(default=0, description="Temperature parameter for the model.", ge=0, le=1)
+
+    top_p: float = Field(default=1, description="Top-p sampling parameter.", ge=0, le=1)
+
+    top_k: int = Field(default=1, description="Top-k sampling parameter.", ge=1)
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize the LLM.
+
+        Args:
+            **kwargs: Configuration options. Supported options:
+                - model_provider: "anthropic" or "openai"
+                - model_name: Name of the model to use
+                - temperature: Temperature parameter (0-1)
+                - top_p: Top-p sampling parameter (0-1)
+                - top_k: Top-k sampling parameter (>= 1)
+        """
+        # Filter out unsupported kwargs
+        supported_kwargs = {"model_provider", "model_name", "temperature", "top_p", "top_k", "callbacks", "tags", "metadata"}
+        filtered_kwargs = {k: v for k, v in kwargs.items() if k in supported_kwargs}
+
+        super().__init__(**filtered_kwargs)
+        self._model = self._get_model()
+
+    @property
+    def _llm_type(self) -> str:
+        """Return identifier for this LLM class."""
+        return "unified_chat_model"
+
+    def _get_model_kwargs(self) -> dict[str, Any]:
+        """Get kwargs for the specific model provider."""
+        base_kwargs = {
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+        }
+
+        if self.model_provider == "anthropic":
+            return {**base_kwargs, "model": self.model_name, "top_k": self.top_k}
+        else:  # openai
+            return {**base_kwargs, "model": self.model_name}
+
+    def _get_model(self) -> BaseChatModel:
+        """Get the appropriate model instance based on configuration."""
+        if self.model_provider == "anthropic":
+            if not os.getenv("ANTHROPIC_API_KEY"):
+                msg = "ANTHROPIC_API_KEY not found in environment. Please set it in your .env file or environment variables."
+                raise ValueError(msg)
+            return ChatAnthropic(**self._get_model_kwargs())
+
+        elif self.model_provider == "openai":
+            if not os.getenv("OPENAI_API_KEY"):
+                msg = "OPENAI_API_KEY not found in environment. Please set it in your .env file or environment variables."
+                raise ValueError(msg)
+            return ChatOpenAI(**self._get_model_kwargs())
+
+        msg = f"Unknown model provider: {self.model_provider}. Must be one of: anthropic, openai"
+        raise ValueError(msg)
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: Optional[list[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        """Generate chat completion using the underlying model.
+
+        Args:
+            messages: The messages to generate from
+            stop: Optional list of stop sequences
+            run_manager: Optional callback manager for tracking the run
+            **kwargs: Additional arguments to pass to the model
+
+        Returns:
+            ChatResult containing the generated completion
+        """
+        return self._model._generate(messages, stop=stop, run_manager=run_manager, **kwargs)

--- a/tests/unit/codegen/extensions/langchain/test_llm.py
+++ b/tests/unit/codegen/extensions/langchain/test_llm.py
@@ -1,0 +1,157 @@
+"""Tests for the unified LLM class."""
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import HumanMessage
+from langchain_openai import ChatOpenAI
+
+from codegen.extensions.langchain.llm import LLM
+
+
+@pytest.fixture
+def mock_env():
+    """Mock environment with API keys."""
+    original_env = dict(os.environ)
+    os.environ.update(
+        {
+            "ANTHROPIC_API_KEY": "test-anthropic-key",
+            "OPENAI_API_KEY": "test-openai-key",
+        }
+    )
+    yield
+    os.environ.clear()
+    os.environ.update(original_env)
+
+
+def test_init_default_anthropic(mock_env):
+    """Test default initialization with Anthropic."""
+    llm = LLM()
+    assert isinstance(llm._model, ChatAnthropic)
+    assert llm.model_provider == "anthropic"
+    assert llm.model_name == "claude-3-5-sonnet-latest"
+    assert llm.temperature == 0
+    assert llm.top_p == 1
+    assert llm.top_k == 1
+
+
+def test_init_openai(mock_env):
+    """Test initialization with OpenAI."""
+    llm = LLM(
+        model_provider="openai",
+        model_name="gpt-4",
+        temperature=0.7,
+        top_p=0.9,
+    )
+    assert isinstance(llm._model, ChatOpenAI)
+    assert llm.model_provider == "openai"
+    assert llm.model_name == "gpt-4"
+    assert llm.temperature == 0.7
+    assert llm.top_p == 0.9
+
+
+def test_anthropic_missing_api_key():
+    """Test error when Anthropic API key is missing."""
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ValueError) as exc_info:
+            LLM()
+        assert "ANTHROPIC_API_KEY not found" in str(exc_info.value)
+
+
+def test_openai_missing_api_key():
+    """Test error when OpenAI API key is missing."""
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ValueError) as exc_info:
+            LLM(model_provider="openai")
+        assert "OPENAI_API_KEY not found" in str(exc_info.value)
+
+
+def test_invalid_model_provider():
+    """Test error with invalid model provider."""
+    with pytest.raises(ValueError) as exc_info:
+        LLM(model_provider="invalid")
+    assert "Input should be 'anthropic' or 'openai'" in str(exc_info.value)
+
+
+def test_invalid_temperature():
+    """Test error with invalid temperature."""
+    with pytest.raises(ValueError) as exc_info:
+        LLM(temperature=2.0)
+    assert "temperature" in str(exc_info.value)
+
+
+def test_invalid_top_p():
+    """Test error with invalid top_p."""
+    with pytest.raises(ValueError) as exc_info:
+        LLM(top_p=2.0)
+    assert "top_p" in str(exc_info.value)
+
+
+def test_invalid_top_k():
+    """Test error with invalid top_k."""
+    with pytest.raises(ValueError) as exc_info:
+        LLM(top_k=0)
+    assert "top_k" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_generate_anthropic(mock_env):
+    """Test generate with Anthropic model."""
+    llm = LLM()
+    messages = [HumanMessage(content="Hello!")]
+
+    # Mock the underlying model's _generate method
+    mock_generate = AsyncMock()
+    with patch.object(ChatAnthropic, "_generate", mock_generate):
+        await llm._generate(messages)
+        mock_generate.assert_called_once_with(
+            messages,
+            stop=None,
+            run_manager=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_generate_openai(mock_env):
+    """Test generate with OpenAI model."""
+    llm = LLM(model_provider="openai")
+    messages = [HumanMessage(content="Hello!")]
+
+    # Mock the underlying model's _generate method
+    mock_generate = AsyncMock()
+    with patch.object(ChatOpenAI, "_generate", mock_generate):
+        await llm._generate(messages)
+        mock_generate.assert_called_once_with(
+            messages,
+            stop=None,
+            run_manager=None,
+        )
+
+
+def test_unsupported_kwargs(mock_env):
+    """Test that unsupported kwargs are filtered out."""
+    llm = LLM(
+        unsupported_kwarg="value",
+        temperature=0.5,
+    )
+    assert not hasattr(llm, "unsupported_kwarg")
+    assert llm.temperature == 0.5
+
+
+@pytest.mark.asyncio
+async def test_stop_sequence(mock_env):
+    """Test that stop sequences are passed through."""
+    llm = LLM()
+    messages = [HumanMessage(content="Hello!")]
+    stop = ["STOP"]
+
+    mock_generate = AsyncMock()
+    with patch.object(ChatAnthropic, "_generate", mock_generate):
+        await llm._generate(messages, stop=stop)
+        mock_generate.assert_called_once_with(
+            messages,
+            stop=stop,
+            run_manager=None,
+        )


### PR DESCRIPTION
- LLM class extends Base LLM class from Langchain (returns a runnable so works like a normal runnable)
- More structured way to switch models instead of adding a bunch of if statements in the agents.py file
-  error handling, etc 


Now can do: 

```python
from llm import LLM

llm = LLM(model_provider="anthropic", model_name="claude-3-5-sonnet-latest")
```