### PR TITLE
fix: remove secrets_ prefix from github token envvar key

### DIFF
--- a/src/codegen/cli/auth/session.py
+++ b/src/codegen/cli/auth/session.py
@@ -65,7 +65,7 @@ class CodegenSession:
         if git_token is None:
             rich.print("\n[bold yellow]Warning:[/bold yellow] GitHub token not found")
             rich.print("To enable full functionality, please set your GitHub token:")
-            rich.print(format_command("export SECRETS_GITHUB_TOKEN=<your-token>"))
+            rich.print(format_command("export GITHUB_TOKEN=<your-token>"))
             rich.print("Or pass in as a parameter:")
             rich.print(format_command("codegen init --token <your-token>"))
 

--- a/src/codegen/configs/models/secrets.py
+++ b/src/codegen/configs/models/secrets.py
@@ -4,7 +4,7 @@ from codegen.configs.models.base_config import BaseConfig
 class SecretsConfig(BaseConfig):
     """Configuration for various API secrets and tokens.
 
-    Loads from environment variables with the SECRETS_ prefix.
+    Loads from environment variables.
     Falls back to .env file for missing values.
     """
 

--- a/src/codegen/runner/clients/codebase_client.py
+++ b/src/codegen/runner/clients/codebase_client.py
@@ -31,7 +31,7 @@ class CodebaseClient(LocalServerClient):
             "REPOSITORY_PATH": str(self.repo_config.repo_path),
         }
         if self.git_access_token is not None:
-            codebase_envs["SECRETS_GITHUB_TOKEN"] = self.git_access_token
+            codebase_envs["GITHUB_TOKEN"] = self.git_access_token
 
         envs.update(codebase_envs)
         return envs

--- a/tests/integration/extension/test_github.py
+++ b/tests/integration/extension/test_github.py
@@ -12,9 +12,9 @@ from codegen.sdk.core.codebase import Codebase
 @pytest.fixture
 def client() -> LinearClient:
     """Create a Linear client for testing."""
-    token = os.getenv("SECRETS_GITHUB_TOKEN")
+    token = os.getenv("GITHUB_TOKEN")
     if not token:
-        pytest.skip("SECRETS_GITHUB_TOKEN environment variable not set")
+        pytest.skip("GITHUB_TOKEN environment variable not set")
     codebase = Codebase.from_repo("codegen-sh/Kevin-s-Adventure-Game")
     return codebase
 


### PR DESCRIPTION
# Motivation

<!-- Why is this change necessary? -->

# Content

<!-- Please include a summary of the change -->

# Testing

<!-- How was the change tested? -->

# Please check the following before marking your PR as ready for review

- [ ] I have added tests for my changes
- [ ] I have updated the documentation or added new documentation as needed
