### PR TITLE
fix: default back to bot_commit=False on RepoOperator

### DIFF
--- a/src/codegen/git/repo_operator/repo_operator.py
+++ b/src/codegen/git/repo_operator/repo_operator.py
@@ -52,7 +52,7 @@ class RepoOperator:
         self,
         repo_config: RepoConfig,
         access_token: str | None = None,
-        bot_commit: bool = True,
+        bot_commit: bool = False,
         setup_option: SetupOption | None = None,
         shallow: bool | None = None,
     ) -> None:


### PR DESCRIPTION
# Motivation

<!-- Why is this change necessary? -->

# Content

<!-- Please include a summary of the change -->

# Testing

<!-- How was the change tested? -->

# Please check the following before marking your PR as ready for review

- [ ] I have added tests for my changes
- [ ] I have updated the documentation or added new documentation as needed
