### PR TITLE
chore: remove unnecessary keep codemods

### DIFF
--- a/src/codegen/cli/workspace/initialize_workspace.py
+++ b/src/codegen/cli/workspace/initialize_workspace.py
@@ -108,15 +108,12 @@ def modify_gitignore(codegen_folder: Path):
         "codegen-system-prompt.txt",
         "",
         "# Python cache files",
-        "__pycache__/",
+        "**/__pycache__/",
         "*.py[cod]",
         "*$py.class",
         "*.txt",
         "*.pyc",
         "",
-        "# Keep codemods",
-        "!codemods/",
-        "!codemods/**",
     ]
 
     # Write or update .gitignore


### PR DESCRIPTION
we don't need this since by default they are kept? unless a rule earlier ignores them