### PR TITLE
CG-10921: Dict Merging + Unwrap Fixes

### DIFF
--- a/src/codegen/sdk/core/symbol_groups/dict.py
+++ b/src/codegen/sdk/core/symbol_groups/dict.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterator, MutableMapping
-from typing import TYPE_CHECKING, Generic, Self, TypeVar
+from typing import TYPE_CHECKING, Generic, Self, TypeVar, overload
 
 from tree_sitter import Node as TSNode
 
@@ -86,15 +86,23 @@ class Dict(Expression[Parent], Builtin, MutableMapping[str, TExpression], Generi
     """
 
     _underlying: Collection[Pair[TExpression, Self] | Unpack[Self], Parent]
-    unpack: Unpack[Self] | None = None
+    unpacks: list[Unpack[Self]] = []  # Store all spread elements
 
     def __init__(self, ts_node: TSNode, file_node_id: NodeId, ctx: "CodebaseContext", parent: Parent, delimiter: str = ",", pair_type: type[Pair] = Pair) -> None:
-        # TODO: handle spread_element
         super().__init__(ts_node, file_node_id, ctx, parent)
-        children = [pair_type(child, file_node_id, ctx, self) for child in ts_node.named_children if child.type not in (None, "comment", "spread_element", "dictionary_splat") and not child.is_error]
-        if unpack := self.child_by_field_types({"spread_element", "dictionary_splat"}):
-            children.append(unpack)
-            self.unpack = unpack
+        children = []
+        self.unpacks = []  # Store all spread elements
+
+        for child in ts_node.named_children:
+            if child.type in (None, "comment") or child.is_error:
+                continue
+            if child.type in ("spread_element", "dictionary_splat"):
+                unpack = Unpack(child, file_node_id, ctx, self)
+                children.append(unpack)
+                self.unpacks.append(unpack)  # Keep track of all spread elements
+            else:
+                children.append(pair_type(child, file_node_id, ctx, self))
+
         if len(children) > 1:
             first_child = children[0].ts_node.end_byte - ts_node.start_byte
             second_child = children[1].ts_node.start_byte - ts_node.start_byte
@@ -107,7 +115,14 @@ class Dict(Expression[Parent], Builtin, MutableMapping[str, TExpression], Generi
     def __len__(self) -> int:
         return len(list(elem for elem in self._underlying if isinstance(elem, Pair)))
 
+    def _get_unpacked_items(self) -> Iterator[tuple[str, TExpression]]:
+        """Get key-value pairs from all unpacked dictionaries."""
+        for unpack in self.unpacks:
+            if isinstance(unpack.value, Dict):
+                yield from unpack.value.items()
+
     def __iter__(self) -> Iterator[str]:
+        # First yield keys from regular pairs
         for pair in self._underlying:
             if isinstance(pair, Pair):
                 if pair.key is not None:
@@ -115,18 +130,31 @@ class Dict(Expression[Parent], Builtin, MutableMapping[str, TExpression], Generi
                         yield pair.key.content
                     else:
                         yield pair.key.source
+        # Then yield keys from unpacked dictionaries
+        for unpack in self.unpacks:
+            for key, _ in self._get_unpacked_items():
+                yield key
 
     def __getitem__(self, __key) -> TExpression:
-        for pair in self._underlying:
-            if isinstance(pair, Pair):
-                if isinstance(pair.key, String):
-                    if pair.key.content == str(__key):
-                        return pair.value
-                elif pair.key is not None:
-                    if pair.key.source == str(__key):
-                        return pair.value
-        msg = f"Key {__key} not found in {list(self.keys())} {self._underlying!r}"
-        raise KeyError(msg)
+        # First try regular pairs
+        try:
+            for pair in self._underlying:
+                if isinstance(pair, Pair):
+                    if isinstance(pair.key, String):
+                        if pair.key.content == str(__key):
+                            return pair.value
+                    elif pair.key is not None:
+                        if pair.key.source == str(__key):
+                            return pair.value
+            # Then try unpacked dictionaries
+            for unpack in self.unpacks:
+                for key, value in self._get_unpacked_items():
+                    if key == str(__key):
+                        return value
+            raise KeyError
+        except KeyError:
+            msg = f"Key {__key} not found in {list(self.keys())} {self._underlying!r}"
+            raise KeyError(msg)
 
     def __setitem__(self, __key, __value: TExpression) -> None:
         new_value = __value.source if isinstance(__value, Editable) else str(__value)
@@ -178,3 +206,221 @@ class Dict(Expression[Parent], Builtin, MutableMapping[str, TExpression], Generi
     @property
     def __class__(self):
         return dict
+
+    def __repr__(self) -> str:
+        """Return a string representation of the dictionary including spread elements."""
+        items = []
+
+        # Add spread elements in their original position
+        for child in self._underlying:
+            if isinstance(child, Unpack):
+                items.append(child.source)
+            else:  # Regular key-value pair
+                if child.key is not None:
+                    if isinstance(child.key, String):
+                        key = child.key.content
+                    else:
+                        key = child.key.source
+                    items.append(f"{key}: {child.value.source}")
+
+        return "{" + ", ".join(items) + "}"
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def _get_all_unpacks_and_keys(self, seen_unpacks: set, seen_keys: set) -> None:
+        """Recursively get all unpacks and their keys from this dictionary and its dependencies.
+
+        Args:
+            seen_unpacks: Set to store all found unpacks
+            seen_keys: Set to store all keys from unpacked dictionaries
+        """
+        for child in self._underlying:
+            if isinstance(child, Unpack):
+                # Get the name being unpacked (e.g., "base1" from "**base1")
+                unpack_name = child.source.strip("*")
+                seen_unpacks.add(unpack_name)
+
+                unpacked_dict = self.file.get_symbol(unpack_name).value
+                if isinstance(unpacked_dict, Dict):
+                    # Add all keys from this dict
+                    for unpacked_child in unpacked_dict._underlying:
+                        if not isinstance(unpacked_child, Unpack) and unpacked_child.key is not None:
+                            seen_keys.add(unpacked_child.key.source)
+                    # Recursively check its unpacks
+                    unpacked_dict._get_all_unpacks_and_keys(seen_unpacks, seen_keys)
+
+    def _get_unpack_name(self, unpack_source: str) -> str:
+        """Get the name being unpacked from the source.
+
+        Args:
+            unpack_source: Source code of the unpack (e.g., "**base1" or "...base1")
+
+        Returns:
+            Name being unpacked (e.g., "base1")
+        """
+        if unpack_source.startswith("**"):
+            return unpack_source.strip("*")
+        elif unpack_source.startswith("..."):
+            return unpack_source[3:]  # Remove the three dots
+        return unpack_source
+
+    @overload
+    def merge(self, *others: "Dict[TExpression, Parent]") -> None: ...
+
+    @overload
+    def merge(self, dict_str: str) -> None: ...
+
+    def merge(self, *others: "Dict[TExpression, Parent] | str") -> None:
+        """Merge multiple dictionaries into a new dictionary
+
+        Preserves spread operators and function calls in their original form.
+        Later dictionaries take precedence over earlier ones for duplicate keys.
+
+        Args:
+            *others: Other Dict objects or a dictionary string to merge.
+                    The string can be either a Python dict (e.g. "{'x': 1}")
+                    or a TypeScript object (e.g. "{x: 1}")
+
+        Raises:
+            ValueError: If attempting to merge dictionaries with duplicate keys or unpacks
+
+        Returns:
+            None
+        """
+        # Track seen keys and unpacks to prevent duplicates
+        seen_keys = set()
+        seen_unpacks = set()
+
+        # Get all unpacks and their keys from the current dictionary and its dependencies
+        self._get_all_unpacks_and_keys(seen_unpacks, seen_keys)
+
+        # Keep track of all items in order
+        merged_items = []
+
+        # First add all items from this dictionary
+        for child in self._underlying:
+            if isinstance(child, Unpack):
+                unpack_source = child.source
+                merged_items.append(unpack_source)
+            else:  # Regular key-value pair
+                if child.key is not None:
+                    key = child.key.source
+                    if key in seen_keys:
+                        msg = f"Duplicate key found: {key}"
+                        raise ValueError(msg)
+                    seen_keys.add(key)
+                    merged_items.append(f"{key}: {child.value.source}")
+
+        # Add items from other dictionaries
+        for other in others:
+            if isinstance(other, Dict):
+                # Handle Dict objects from our SDK
+                for child in other._underlying:
+                    if isinstance(child, Unpack):
+                        unpack_source = child.source
+                        # Get the name being unpacked (e.g., "base1" from "**base1")
+                        unpack_name = self._get_unpack_name(unpack_source)
+                        if unpack_name in seen_unpacks:
+                            msg = f"Duplicate unpack found: {unpack_source}"
+                            raise ValueError(msg)
+                        seen_unpacks.add(unpack_name)
+                        merged_items.append(unpack_source)
+                    else:  # Regular key-value pair
+                        if child.key is not None:
+                            key = child.key.source
+                            if key in seen_keys:
+                                msg = f"Duplicate key found: {key}"
+                                raise ValueError(msg)
+                            seen_keys.add(key)
+                            merged_items.append(f"{key}: {child.value.source}")
+            elif isinstance(other, str):
+                # Handle dictionary strings
+                # Strip curly braces and whitespace
+                content = other.strip().strip("{}").strip()
+                if not content:  # Skip empty dicts
+                    continue
+
+                # Parse the content to check for duplicates
+                parts = content.split(",")
+                for part in parts:
+                    part = part.strip()
+                    if part.startswith("**"):
+                        # Get the name being unpacked (e.g., "base1" from "**base1")
+                        unpack_name = self._get_unpack_name(part)
+                        if unpack_name in seen_unpacks:
+                            msg = f"Duplicate unpack found: {part}"
+                            raise ValueError(msg)
+
+                        unpacked_dict = self.file.get_symbol(unpack_name).value
+                        if isinstance(unpacked_dict, Dict):
+                            # Add all keys from this dict
+                            for unpacked_child in unpacked_dict._underlying:
+                                if not isinstance(unpacked_child, Unpack) and unpacked_child.key is not None:
+                                    if unpacked_child.key.source in seen_keys:
+                                        msg = f"Duplicate key found: {unpacked_child.key.source}"
+                                        raise ValueError(msg)
+
+                        seen_unpacks.add(unpack_name)
+                        merged_items.append(part)
+                    else:
+                        # It's a key-value pair
+                        key = part.split(":")[0].strip()
+                        if key in seen_keys:
+                            msg = f"Duplicate key found: {key}"
+                            raise ValueError(msg)
+                        seen_keys.add(key)
+                        merged_items.append(part)
+            else:
+                msg = f"Cannot merge with object of type {type(other)}"
+                raise TypeError(msg)
+
+        # Create merged source
+        merged_source = "{" + ", ".join(merged_items) + "}"
+
+        # Replace this dict's source with merged source
+        self.edit(merged_source)
+
+    def add(self, typescript_dict: str) -> None:
+        """Add a TypeScript dictionary string to this dictionary
+
+        Args:
+            typescript_dict: A TypeScript dictionary string e.g. "{a: 1, b: 2}"
+
+        Returns:
+            None
+        """
+        # Get current items
+        merged_items = []
+
+        # Add all items from this dictionary first
+        for child in self._underlying:
+            if isinstance(child, Unpack):
+                merged_items.append(child.source)
+            elif child.key is not None:
+                merged_items.append(f"{child.key.source}: {child.value.source}")
+
+        # Add the TypeScript dictionary content
+        typescript_dict = typescript_dict.strip().strip("{}").strip()
+        if typescript_dict:  # Only add if not empty
+            merged_items.append(typescript_dict)
+
+        # Create merged source
+        merged_source = "{" + ", ".join(merged_items) + "}"
+
+        # Replace this dict's source with merged source
+        self.edit(merged_source)
+
+    def unwrap(self) -> None:
+        """Unwrap all spread elements in this dictionary.
+
+        This will replace all spread elements with their actual key-value pairs.
+        For example:
+            {'a': 1, ...dict2, 'b': 2} -> {'a': 1, 'c': 3, 'd': 4, 'b': 2}
+
+        Returns:
+            None
+        """
+        # Process all spread elements
+        for unpack in list(self.unpacks):  # Make a copy since we'll modify during iteration
+            unpack.unwrap()

--- a/src/codegen/sdk/typescript/symbol_groups/dict.py
+++ b/src/codegen/sdk/typescript/symbol_groups/dict.py
@@ -151,9 +151,9 @@ class TSDict(Dict[Expression, Parent]):
         In TypeScript, duplicate keys and spreads are allowed - later ones override earlier ones.
 
         Args:
-            *others: Other Dict objects or a dictionary string to merge.
-                    The string can be either a Python dict (e.g. "{'x': 1}")
-                    or a TypeScript object (e.g. "{x: 1}")
+            *others: Other Dict objects or dictionary strings.
+                    The strings can be either Python dicts (e.g. "{'x': 1}")
+                    or TypeScript objects (e.g. "{x: 1}")
 
         Returns:
             None
@@ -178,7 +178,7 @@ class TSDict(Dict[Expression, Parent]):
                     elif child.key is not None:
                         merged_items.append(f"{child.key.source}: {child.value.source}")
             elif isinstance(other, str):
-                # Handle dictionary strings
+                # Handle dictionary string
                 content = other.strip().strip("{}").strip()
                 if not content:  # Skip empty dicts
                     continue


### PR DESCRIPTION
- Merge python dicts or javascript objects together (both normal keys and spread operators)
-
- `Dict.merge(**args: str | Dict)` accepts args of `str | Dict` object

- Calling unwrap on a `Dict` object will unwrap all  spread objects in the dictionary/object which are denoted as the `Unpack` object

- `Dict.unpack` ->  `Dict.unpacks` solves the issue when there are multiple spreak operators so we capture all of them

- Raises error if duplicate keys are present in python. Also recursively travels up spread operators to find duplicate keys 


Examples
```python
# Python
dict1.merge(dict2, dict3)  # Multiple dicts
dict1.merge("{'a': 1, **base1}", "{'b': 2}")       # With spread operator and strings

# TypeScript
dict1.merge(dict2, dict3, "{x: 1}", "{y: 2}")      # Multiple objects
dict1.merge("{a: 1, ...base1}", "{b: 2}")          # With spread operator
```


To find the spread objects you must do the following to loop over everything. These apis were already existing btw
```python
for child in dict1.children
     print(child) # this will include all of the keys and the unpacked 
```
