### PR TITLE
don't traverse into ignored directories

### DIFF
--- a/src/codegen/git/repo_operator/repo_operator.py
+++ b/src/codegen/git/repo_operator/repo_operator.py
@@ -608,7 +608,12 @@ class RepoOperator:
             # -c: show cached files
             # -o: show other / untracked files
             # --exclude-standard: exclude standard gitignore rules
-            return self.git_cli.git.ls_files("-co", "--exclude-standard").split("\n")
+            return [
+                filepath.strip()
+                for filepath in self.git_cli.git.ls_files("-co", "--exclude-standard").split("\n")
+                if filepath.strip()
+                if not self._matches_ignore_list(ignore_list, filepath)
+            ]
 
         filepaths = []
         for dirpath, subdirnames, filenames in os.walk(self.repo_path):
@@ -625,7 +630,7 @@ class RepoOperator:
                 filepath = os.path.join(dirpath, filename)
                 if self._matches_ignore_list(ignore_list, filepath):
                     continue
-                filepaths.append(filepath)
+                filepaths.append(os.path.relpath(filepath, self.repo_path))
 
         return filepaths
 

--- a/src/codegen/git/repo_operator/repo_operator.py
+++ b/src/codegen/git/repo_operator/repo_operator.py
@@ -1,6 +1,5 @@
 import codecs
 import fnmatch
-import glob
 import os
 from collections.abc import Generator
 from datetime import UTC, datetime
@@ -575,19 +574,8 @@ class RepoOperator:
         if os.listdir(self.abspath(os.path.dirname(path))) == []:
             os.rmdir(self.abspath(os.path.dirname(path)))
 
-    def get_filepaths_for_repo(self, ignore_list):
-        # Get list of files to iterate over based on gitignore setting
-        if self.repo_config.respect_gitignore:
-            # ls-file flags:
-            # -c: show cached files
-            # -o: show other / untracked files
-            # --exclude-standard: exclude standard gitignore rules
-            filepaths = self.git_cli.git.ls_files("-co", "--exclude-standard").split("\n")
-        else:
-            filepaths = glob.glob("**", root_dir=self.repo_path, recursive=True, include_hidden=True)
-            # Filter filepaths by ignore list.
-        if ignore_list:
-            filepaths = [f for f in filepaths if not any(fnmatch.fnmatch(f, pattern) or f.startswith(pattern) for pattern in ignore_list)]
+    def get_filepaths_for_repo(self, ignore_list: list[str] | None) -> list[str]:
+        filepaths = self._get_filepaths_for_repo_raw(ignore_list)
 
         # Fix bug where unicode characters are not handled correctly
         for i, filepath in enumerate(filepaths):
@@ -609,6 +597,42 @@ class RepoOperator:
                 filepaths[i] = filepath
 
         return filepaths
+
+    def _get_filepaths_for_repo_raw(self, ignore_list: list[str] | None) -> list[str]:
+        """Walks the directory tree, ignoring any files which match `ignore_list`,
+        and not traversing any directories which match the list.
+        """
+        # Get list of files to iterate over based on gitignore setting
+        if self.repo_config.respect_gitignore:
+            # ls-file flags:
+            # -c: show cached files
+            # -o: show other / untracked files
+            # --exclude-standard: exclude standard gitignore rules
+            return self.git_cli.git.ls_files("-co", "--exclude-standard").split("\n")
+
+        filepaths = []
+        for dirpath, subdirnames, filenames in os.walk(self.repo_path):
+            to_remove = []
+            for i, subdirname in enumerate(subdirnames):
+                subdirpath = os.path.join(dirpath, subdirname)
+                if self._matches_ignore_list(ignore_list, subdirpath):
+                    to_remove.append(i)
+
+            for i in reversed(to_remove):
+                subdirnames.pop(i)
+
+            for filename in filenames:
+                filepath = os.path.join(dirpath, filename)
+                if self._matches_ignore_list(ignore_list, filepath):
+                    continue
+                filepaths.append(filepath)
+
+        return filepaths
+
+    def _matches_ignore_list(self, ignore_list: list[str] | None, filepath: str) -> bool:
+        if ignore_list is None:
+            return False
+        return any(fnmatch.fnmatch(filepath, pattern) or filepath.startswith(pattern) for pattern in ignore_list)
 
     # TODO: unify param naming i.e. subdirectories vs subdirs probably use subdirectories since that's in the DB
     def iter_files(

--- a/tests/unit/codegen/git/repo_operator/test_repo_operator.py
+++ b/tests/unit/codegen/git/repo_operator/test_repo_operator.py
@@ -1,0 +1,68 @@
+import tempfile
+from pathlib import Path
+from typing import Generator
+
+import pytest
+
+from codegen.git.repo_operator.repo_operator import RepoOperator
+from codegen.git.schemas.repo_config import RepoConfig
+from codegen.sdk.codebase.codebase_context import GLOBAL_FILE_IGNORE_LIST
+
+
+@pytest.fixture
+def tmp_dir() -> Generator[Path, None, None]:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        yield Path(tmp_dir)
+
+
+@pytest.fixture(params=[False, True])
+def mock_repo_config(request: pytest.FixtureRequest, tmp_dir: Path) -> RepoConfig:
+    return RepoConfig(
+        name=tmp_dir.name,
+        base_dir=str(tmp_dir.parent),
+        respect_gitignore=request.param,
+    )
+
+
+def test_get_filepaths_for_repo__empty(mock_repo_config: RepoConfig) -> None:
+    repo_operator = RepoOperator(mock_repo_config)
+    filepaths = repo_operator.get_filepaths_for_repo(GLOBAL_FILE_IGNORE_LIST)
+    assert filepaths == []
+
+
+def test_get_filepaths_for_repo__ignored_files(tmp_dir: Path, mock_repo_config: RepoConfig) -> None:
+    for path in [
+        "extra_ignored_dir/something.py",
+        "extra_ignored_dir/oh_no_a_dependency.py",
+    ]:
+        file_path = tmp_dir / path
+        (file_path).parent.mkdir(exist_ok=True, parents=True)
+        file_path.touch()
+    
+    repo_operator = RepoOperator(mock_repo_config)
+    filepaths = repo_operator.get_filepaths_for_repo(
+        GLOBAL_FILE_IGNORE_LIST
+        + [
+            "extra_ignored_dir/*",
+            "*/extra_ignored_dir/*",
+        ],
+    )
+    assert filepaths == []
+
+
+def test_get_filepaths_for_repo__good_files(tmp_dir: Path, mock_repo_config: RepoConfig) -> None:
+    for path in [
+        "src/main.py",
+        "src/something_else.py",
+    ]:
+        file_path = tmp_dir / path
+        (file_path).parent.mkdir(exist_ok=True, parents=True)
+        file_path.touch()
+
+    repo_operator = RepoOperator(mock_repo_config)
+    filepaths = repo_operator.get_filepaths_for_repo(GLOBAL_FILE_IGNORE_LIST)
+    assert sorted(filepaths) == sorted([
+        "src/main.py",
+        "src/something_else.py",
+    ])
+


### PR DESCRIPTION
# Motivation

`get_filepaths_for_repo` currently uses `glob.glob("**", ...)`, and then filters out ignored files from that list. In repos with large swaths of ignored files, this is a lot of unnecessary work.

# Content

This implements a more efficient fallback for when git isn't enabled, which instead skips traversing any content inside of ignored directories, potentially saving a decent amount of time. 

# Testing

Tested against a local repository to check that the results seemed the same. Also added new unit tests for this part of the `RepoOperator`.

<!-- How was the change tested? -->

# Please check the following before marking your PR as ready for review

- [x] I have added tests for my changes
- [ ] I have updated the documentation or added new documentation as needed
