### PR TITLE
don't eagerly read file contents

### DIFF
--- a/src/codegen/git/utils/language.py
+++ b/src/codegen/git/utils/language.py
@@ -133,7 +133,11 @@ def _determine_language_by_git_file_count(folder_path: str) -> ProgrammingLangua
     repo_operator = RepoOperator(repo_config=repo_config)
 
     # Walk through the directory
-    for rel_path, _ in repo_operator.iter_files(subdirs=[base_path] if base_path else None, ignore_list=GLOBAL_FILE_IGNORE_LIST):
+    for rel_path, _ in repo_operator.iter_files(
+        subdirs=[base_path] if base_path else None,
+        ignore_list=GLOBAL_FILE_IGNORE_LIST,
+        skip_content=True,
+    ):
         # Convert to Path object
         file_path = Path(git_root) / Path(rel_path)
 

--- a/src/codegen/sdk/codebase/codebase_context.py
+++ b/src/codegen/sdk/codebase/codebase_context.py
@@ -225,7 +225,12 @@ class CodebaseContext:
         # =====[ Add all files to the graph in parallel ]=====
         syncs = defaultdict(lambda: [])
         if not self.config.disable_file_parse:
-            for filepath, _ in repo_operator.iter_files(subdirs=self.projects[0].subdirectories, extensions=self.extensions, ignore_list=GLOBAL_FILE_IGNORE_LIST):
+            for filepath, _ in repo_operator.iter_files(
+                subdirs=self.projects[0].subdirectories,
+                extensions=self.extensions,
+                ignore_list=GLOBAL_FILE_IGNORE_LIST,
+                skip_content=True,
+            ):
                 syncs[SyncType.ADD].append(self.to_absolute(filepath))
         logger.info(f"> Parsing {len(syncs[SyncType.ADD])} files in {self.projects[0].subdirectories or 'ALL'} subdirectories with {self.extensions} extensions")
         self._process_diff_files(syncs, incremental=False)

--- a/src/codegen/sdk/codebase/validation.py
+++ b/src/codegen/sdk/codebase/validation.py
@@ -37,7 +37,16 @@ def post_init_validation(codebase: CodebaseType) -> PostInitValidationStatus:
         return PostInitValidationStatus.NO_NODES
 
     # Verify the graph has the same number of files as there are in the repo
-    if len(codebase.files) != len(list(codebase.op.iter_files(codebase.ctx.projects[0].subdirectories, extensions=codebase.ctx.extensions, ignore_list=GLOBAL_FILE_IGNORE_LIST))):
+    if len(codebase.files) != len(
+        list(
+            codebase.op.iter_files(
+                codebase.ctx.projects[0].subdirectories,
+                extensions=codebase.ctx.extensions,
+                ignore_list=GLOBAL_FILE_IGNORE_LIST,
+                skip_content=True,
+            )
+        )
+    ):
         return PostInitValidationStatus.MISSING_FILES
 
     # Verify import resolution

--- a/src/codegen/sdk/core/codebase.py
+++ b/src/codegen/sdk/core/codebase.py
@@ -309,6 +309,7 @@ class Codebase(
             for filepath, _ in self._op.iter_files(
                 extensions=None if extensions == "*" else extensions,
                 ignore_list=GLOBAL_FILE_IGNORE_LIST,
+                skip_content=True,
             ):
                 files.append(self.get_file(filepath, optional=False))
         # Sort files alphabetically


### PR DESCRIPTION
# Motivation

Many usages of `iter_files` don't explicitly include `skip_content`, but they don't actually care about the contents of the files. This can slow down codegen when running against a large repository with many large files.

# Content

This PR just adds `skip_content` to all of the `iter_files` references I could find which don't care about the file content.

Note that this...actually is all of the references. The more "right" way to do this may be to change `iter_files` to never return the contents of files, but I didn't want to make that kind of change w/o talking to the maintainers first.

# Testing

Best-effort testing locally. Would like to chat w/ y'all to figure out how to effectively test a change like this.

# Please check the following before marking your PR as ready for review

- [ ] I have added tests for my changes
- [ ] I have updated the documentation or added new documentation as needed
