### PR TITLE
fix: Add `access_token` for `create_from_repo` as well

### DIFF
--- a/src/codegen/sdk/core/codebase.py
+++ b/src/codegen/sdk/core/codebase.py
@@ -1347,11 +1347,11 @@ class Codebase(
         try:
             # Use RepoOperator to fetch the repository
             logger.info("Cloning repository...")
+            access_token = secrets.github_token if secrets else None
             if commit is None:
-                repo_operator = RepoOperator.create_from_repo(repo_path=repo_path, url=repo_url)
+                repo_operator = RepoOperator.create_from_repo(repo_path=repo_path, url=repo_url, access_token=access_token)
             else:
                 # Ensure the operator can handle remote operations
-                access_token = secrets.github_token if secrets else None
                 repo_operator = RepoOperator.create_from_commit(repo_path=repo_path, commit=commit, url=repo_url, full_name=repo_full_name, access_token=access_token)
             logger.info("Clone completed successfully")
 


### PR DESCRIPTION
# Motivation

<!-- Why is this change necessary? -->
Running into authentication error here on my side project:

```
  cmdline: git clone -v --depth=1 -- https://github.com/anantjain-xyz/agent.git /tmp/codegen/agent
  stderr: 'Cloning into '/tmp/codegen/agent'...
fatal: could not read Username for 'https://github.com': No such device or address
'
2025-03-05 04:53:28,972 - codegen.git.repo_operator.repo_operator - ERROR - Please authenticate with a valid token and ensure the repository is properly initialized.
```

# Content

<!-- Please include a summary of the change -->
Make sure that the `access_token` is passed for the `create_from_repo` method as well, especially when you don't want `GITHUB_TOKEN` to be part of secrets config.

# Testing

<!-- How was the change tested? -->

# Please check the following before marking your PR as ready for review

- [ ] I have added tests for my changes
- [ ] I have updated the documentation or added new documentation as needed
