### PR TITLE
chore: better linking between a swebench run and its langsmith trace

### DIFF
--- a/codegen-examples/examples/swebench_agent_run/entry_point.py
+++ b/codegen-examples/examples/swebench_agent_run/entry_point.py
@@ -14,6 +14,6 @@ app = modal.App(name="swebench-agent-run", image=image, secrets=[modal.Secret.fr
 
 
 @app.function(timeout=43200)
-async def run_agent_modal(entry: SweBenchExample):
+async def run_agent_modal(entry: SweBenchExample, run_id: str):
     """Modal function to process a single example from the SWE-bench dataset."""
-    return run_agent_on_entry(entry)
+    return run_agent_on_entry(entry, run_id=run_id)

--- a/src/codegen/agents/code_agent.py
+++ b/src/codegen/agents/code_agent.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 from langchain.tools import BaseTool
 from langchain_core.messages import AIMessage
+from langchain_core.runnables.config import RunnableConfig
 from langsmith import Client
 
 from codegen.extensions.langchain.agent import create_codebase_agent
@@ -16,7 +17,17 @@ if TYPE_CHECKING:
 class CodeAgent:
     """Agent for interacting with a codebase."""
 
-    def __init__(self, codebase: "Codebase", model_provider: str = "anthropic", model_name: str = "claude-3-5-sonnet-latest", memory: bool = True, tools: Optional[list[BaseTool]] = None, **kwargs):
+    def __init__(
+        self,
+        codebase: "Codebase",
+        model_provider: str = "anthropic",
+        model_name: str = "claude-3-7-sonnet-latest",
+        memory: bool = True,
+        tools: Optional[list[BaseTool]] = None,
+        run_id: Optional[str] = None,
+        instance_id: Optional[str] = None,
+        **kwargs,
+    ):
         """Initialize a CodeAgent.
 
         Args:
@@ -34,6 +45,8 @@ class CodeAgent:
         self.codebase = codebase
         self.agent = create_codebase_agent(self.codebase, model_provider=model_provider, model_name=model_name, memory=memory, additional_tools=tools, **kwargs)
         self.langsmith_client = Client()
+        self.run_id = run_id
+        self.instance_id = instance_id
 
         # Get project name from environment variable or use a default
         self.project_name = os.environ.get("LANGCHAIN_PROJECT", "RELACE")
@@ -55,9 +68,20 @@ class CodeAgent:
         # this message has a reducer which appends the current message to the existing history
         # see more https://langchain-ai.github.io/langgraph/concepts/low_level/#reducers
         input = {"messages": [("user", prompt)]}
+        metadata = {"project": self.project_name}
+        tags = []
+        # Add SWEBench run ID and instance ID to the metadata and tags for filtering
+        if self.run_id is not None:
+            metadata["swebench_run_id"] = self.run_id
+            tags.append(self.run_id)
 
+        if self.instance_id is not None:
+            metadata["swebench_instance_id"] = self.instance_id
+            tags.append(self.instance_id)
+
+        config = RunnableConfig(configurable={"thread_id": thread_id}, tags=tags, metadata=metadata, recursion_limit=100)
         # we stream the steps instead of invoke because it allows us to access intermediate nodes
-        stream = self.agent.stream(input, config={"configurable": {"thread_id": thread_id, "metadata": {"project": self.project_name}}, "recursion_limit": 100}, stream_mode="values")
+        stream = self.agent.stream(input, config=config, stream_mode="values")
 
         # Keep track of run IDs from the stream
         run_ids = []

--- a/src/codegen/extensions/swebench/harness.py
+++ b/src/codegen/extensions/swebench/harness.py
@@ -49,7 +49,7 @@ def show_problems(dataset):
         print(f"{inst}: {problem}")
 
 
-def run_agent_on_entry(entry: SweBenchExample, codebase: Codebase | None = None):
+def run_agent_on_entry(entry: SweBenchExample, codebase: Codebase | None = None, run_id: str | None = None):
     """Process one `entry` from SWE Bench using the LLM `models` at the
     given `temperature`.  Set `model_name_or_path` in the result json.
     """
@@ -70,7 +70,7 @@ def run_agent_on_entry(entry: SweBenchExample, codebase: Codebase | None = None)
         )
         codebase = Codebase.from_repo(repo_full_name=entry.repo, commit=base_commit, language="python", config=config)  # check out the repo
 
-    agent = CodeAgent(codebase=codebase)
+    agent = CodeAgent(codebase=codebase, run_id=run_id, instance_id=instance_id)
 
     pprint.pprint(instance_id)
     pprint.pprint(gold_files)


### PR DESCRIPTION
# Motivation

Currently there isn't a good way to find a langsmith trace given a run_id and instance_id

# Content

<!-- Please include a summary of the change -->

# Testing

<!-- How was the change tested? -->

# Please check the following before marking your PR as ready for review

- [ ] I have added tests for my changes
- [ ] I have updated the documentation or added new documentation as needed
