### PR TITLE
chore: model is now a parameter for the run eval command

### DIFF
--- a/codegen-examples/examples/swebench_agent_run/entry_point.py
+++ b/codegen-examples/examples/swebench_agent_run/entry_point.py
@@ -14,6 +14,6 @@ app = modal.App(name="swebench-agent-run", image=image, secrets=[modal.Secret.fr
 
 
 @app.function(timeout=43200)
-async def run_agent_modal(entry: SweBenchExample, run_id: str):
+async def run_agent_modal(entry: SweBenchExample, run_id: str, model: str):
     """Modal function to process a single example from the SWE-bench dataset."""
-    return run_agent_on_entry(entry, run_id=run_id)
+    return run_agent_on_entry(entry, run_id=run_id, model=model)

--- a/src/codegen/extensions/swebench/harness.py
+++ b/src/codegen/extensions/swebench/harness.py
@@ -49,7 +49,7 @@ def show_problems(dataset):
         print(f"{inst}: {problem}")
 
 
-def run_agent_on_entry(entry: SweBenchExample, codebase: Codebase | None = None, run_id: str | None = None):
+def run_agent_on_entry(entry: SweBenchExample, model: str, codebase: Codebase | None = None, run_id: str | None = None):
     """Process one `entry` from SWE Bench using the LLM `models` at the
     given `temperature`.  Set `model_name_or_path` in the result json.
     """
@@ -70,7 +70,7 @@ def run_agent_on_entry(entry: SweBenchExample, codebase: Codebase | None = None,
         )
         codebase = Codebase.from_repo(repo_full_name=entry.repo, commit=base_commit, language="python", config=config)  # check out the repo
 
-    agent = CodeAgent(codebase=codebase, run_id=run_id, instance_id=instance_id)
+    agent = CodeAgent(codebase=codebase, run_id=run_id, instance_id=instance_id, model_name=model)
 
     pprint.pprint(instance_id)
     pprint.pprint(gold_files)


### PR DESCRIPTION
# Motivation

Currently there is no way to specify which model to use from the command line when running the swe bench eval.

# Content

Passes model name through the functions

# Testing

This is a test

# Please check the following before marking your PR as ready for review

- [x] I have added tests for my changes
- [x] I have updated the documentation or added new documentation as needed
