### PR TITLE
Model name is a tag for langsmith traces

### DIFF
--- a/src/codegen/agents/code_agent.py
+++ b/src/codegen/agents/code_agent.py
@@ -60,6 +60,7 @@ class CodeAgent:
             additional_tools=tools,
             **kwargs,
         )
+        self.model_name = model_name
         self.langsmith_client = Client()
         self.run_id = run_id
         self.instance_id = instance_id
@@ -92,8 +93,8 @@ class CodeAgent:
         # this message has a reducer which appends the current message to the existing history
         # see more https://langchain-ai.github.io/langgraph/concepts/low_level/#reducers
         input = {"messages": [("user", prompt)]}
-        metadata = {"project": self.project_name}
-        tags = []
+        metadata = {"project": self.project_name, "model": self.model_name}
+        tags = [self.model_name]
         # Add SWEBench run ID and instance ID to the metadata and tags for filtering
         if self.run_id is not None:
             metadata["swebench_run_id"] = self.run_id


### PR DESCRIPTION
# Motivation

We need a quick way to filter langsmith traces by model name.

# Content

Model name is now an attribute of CodeAgent and is added to the list of tags on the langsmith trace.

# Testing

Tested by running locally

# Please check the following before marking your PR as ready for review

