### PR TITLE
Adding Schema for Tool Outputs

### DIFF
--- a/codegen-examples/examples/swebench_agent_run/local_run.ipynb
+++ b/codegen-examples/examples/swebench_agent_run/local_run.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "await run_eval(use_existing_preds=None, dataset=\"lite\", length=20, repo=\"django/django\", num_workers=10, model=\"claude-3-7-sonnet-latest\")"
+    "await run_eval(use_existing_preds=None, dataset=\"lite\", length=5, repo=\"django/django\", num_workers=10, model=\"claude-3-7-sonnet-latest\")"
    ]
   },
   {

--- a/src/codegen/agents/data.py
+++ b/src/codegen/agents/data.py
@@ -52,6 +52,7 @@ class ToolMessageData(BaseMessage):
     tool_name: Optional[str] = None
     tool_response: Optional[str] = None
     tool_id: Optional[str] = None
+    status: Optional[str] = None
 
 
 @dataclass

--- a/src/codegen/agents/tracer.py
+++ b/src/codegen/agents/tracer.py
@@ -75,7 +75,7 @@ class MessageStreamTracer:
                 type=message_type,
                 content=content,
                 tool_name=getattr(latest_message, "name", None),
-                tool_response=content,
+                tool_response=getattr(latest_message, "artifact", content),
                 tool_id=getattr(latest_message, "tool_call_id", None),
                 status=getattr(latest_message, "status", None),
             )

--- a/src/codegen/agents/tracer.py
+++ b/src/codegen/agents/tracer.py
@@ -71,7 +71,14 @@ class MessageStreamTracer:
             tool_calls = [ToolCall(name=tc.get("name"), arguments=tc.get("arguments"), id=tc.get("id")) for tc in tool_calls_data]
             return AssistantMessage(type=message_type, content=content, tool_calls=tool_calls)
         elif message_type == "tool":
-            return ToolMessageData(type=message_type, content=content, tool_name=getattr(latest_message, "name", None), tool_response=content, tool_id=getattr(latest_message, "tool_call_id", None))
+            return ToolMessageData(
+                type=message_type,
+                content=content,
+                tool_name=getattr(latest_message, "name", None),
+                tool_response=content,
+                tool_id=getattr(latest_message, "tool_call_id", None),
+                status=getattr(latest_message, "status", None),
+            )
         elif message_type == "function":
             return FunctionMessageData(type=message_type, content=content)
         else:

--- a/src/codegen/extensions/langchain/graph.py
+++ b/src/codegen/extensions/langchain/graph.py
@@ -100,7 +100,7 @@ class AgentGraph:
             messages.append(HumanMessage(content=query))
 
         result = self.model.invoke([self.system_message, *messages])
-        if isinstance(result, AIMessage):
+        if isinstance(result, AIMessage) and not result.tool_calls:
             updated_messages = [*messages, result]
             return {"messages": updated_messages, "final_answer": result.content}
 
@@ -455,7 +455,7 @@ class AgentGraph:
                     return f"Error: Could not identify the tool you're trying to use.\n\nAvailable tools:\n{available_tools}\n\nPlease use one of the available tools with the correct parameters."
 
             # For other types of errors
-            return f"Error executing tool: {error_msg}\n\nPlease check your tool usage and try again with the correct parameters."
+            return f"Error executing tool: {exception!s}\n\nPlease check your tool usage and try again with the correct parameters."
 
         # Add nodes
         builder.add_node("reasoner", self.reasoner, retry=retry_policy)

--- a/src/codegen/extensions/langchain/tools.py
+++ b/src/codegen/extensions/langchain/tools.py
@@ -1,7 +1,9 @@
 """Langchain tools for workspace operations."""
 
-from typing import Callable, ClassVar, Literal, Optional
+from typing import Annotated, Callable, ClassVar, Literal, Optional
 
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import InjectedToolCallId
 from langchain_core.tools.base import BaseTool
 from pydantic import BaseModel, Field
 
@@ -53,6 +55,7 @@ class ViewFileInput(BaseModel):
     end_line: Optional[int] = Field(None, description="Ending line number to view (1-indexed, inclusive)")
     max_lines: Optional[int] = Field(None, description="Maximum number of lines to view at once, defaults to 250")
     line_numbers: Optional[bool] = Field(True, description="If True, add line numbers to the content (1-indexed)")
+    tool_call_id: Annotated[str, InjectedToolCallId]
 
 
 class ViewFileTool(BaseTool):
@@ -70,12 +73,13 @@ The response will indicate if there are more lines available to view."""
 
     def _run(
         self,
+        tool_call_id: str,
         filepath: str,
         start_line: Optional[int] = None,
         end_line: Optional[int] = None,
         max_lines: Optional[int] = None,
         line_numbers: Optional[bool] = True,
-    ) -> str:
+    ) -> ToolMessage:
         result = view_file(
             self.codebase,
             filepath,
@@ -85,7 +89,7 @@ The response will indicate if there are more lines available to view."""
             max_lines=max_lines if max_lines is not None else 250,
         )
 
-        return result.render()
+        return result.render(tool_call_id)
 
 
 class ListDirectoryInput(BaseModel):
@@ -93,6 +97,7 @@ class ListDirectoryInput(BaseModel):
 
     dirpath: str = Field(default="./", description="Path to directory relative to workspace root")
     depth: int = Field(default=1, description="How deep to traverse. Use -1 for unlimited depth.")
+    tool_call_id: Annotated[str, InjectedToolCallId]
 
 
 class ListDirectoryTool(BaseTool):
@@ -106,9 +111,9 @@ class ListDirectoryTool(BaseTool):
     def __init__(self, codebase: Codebase) -> None:
         super().__init__(codebase=codebase)
 
-    def _run(self, dirpath: str = "./", depth: int = 1) -> str:
+    def _run(self, tool_call_id: str, dirpath: str = "./", depth: int = 1) -> ToolMessage:
         result = list_directory(self.codebase, dirpath, depth)
-        return result.render()
+        return result.render(tool_call_id)
 
 
 class SearchInput(BaseModel):
@@ -123,6 +128,7 @@ class SearchInput(BaseModel):
     page: int = Field(default=1, description="Page number to return (1-based, default: 1)")
     files_per_page: int = Field(default=10, description="Number of files to return per page (default: 10)")
     use_regex: bool = Field(default=False, description="Whether to treat query as a regex pattern (default: False)")
+    tool_call_id: Annotated[str, InjectedToolCallId]
 
 
 class SearchTool(BaseTool):
@@ -136,9 +142,9 @@ class SearchTool(BaseTool):
     def __init__(self, codebase: Codebase) -> None:
         super().__init__(codebase=codebase)
 
-    def _run(self, query: str, file_extensions: Optional[list[str]] = None, page: int = 1, files_per_page: int = 10, use_regex: bool = False) -> str:
+    def _run(self, tool_call_id: str, query: str, file_extensions: Optional[list[str]] = None, page: int = 1, files_per_page: int = 10, use_regex: bool = False) -> ToolMessage:
         result = search(self.codebase, query, file_extensions=file_extensions, page=page, files_per_page=files_per_page, use_regex=use_regex)
-        return result.render()
+        return result.render(tool_call_id)
 
 
 class EditFileInput(BaseModel):
@@ -146,6 +152,7 @@ class EditFileInput(BaseModel):
 
     filepath: str = Field(..., description="Path to the file to edit")
     content: str = Field(..., description="New content for the file")
+    tool_call_id: Annotated[str, InjectedToolCallId]
 
 
 class EditFileTool(BaseTool):
@@ -178,9 +185,9 @@ Input for searching the codebase.
     def __init__(self, codebase: Codebase) -> None:
         super().__init__(codebase=codebase)
 
-    def _run(self, filepath: str, content: str) -> str:
+    def _run(self, filepath: str, content: str, tool_call_id: str) -> str:
         result = edit_file(self.codebase, filepath, content)
-        return result.render()
+        return result.render(tool_call_id)
 
 
 class CreateFileInput(BaseModel):
@@ -337,6 +344,7 @@ class SemanticEditInput(BaseModel):
     edit_content: str = Field(..., description=FILE_EDIT_PROMPT)
     start: int = Field(default=1, description="Starting line number (1-indexed, inclusive). Default is 1.")
     end: int = Field(default=-1, description="Ending line number (1-indexed, inclusive). Default is -1 (end of file).")
+    tool_call_id: Annotated[str, InjectedToolCallId]
 
 
 class SemanticEditTool(BaseTool):
@@ -350,10 +358,10 @@ class SemanticEditTool(BaseTool):
     def __init__(self, codebase: Codebase) -> None:
         super().__init__(codebase=codebase)
 
-    def _run(self, filepath: str, edit_content: str, start: int = 1, end: int = -1) -> str:
+    def _run(self, filepath: str, tool_call_id: str, edit_content: str, start: int = 1, end: int = -1) -> ToolMessage:
         # Create the the draft editor mini llm
         result = semantic_edit(self.codebase, filepath, edit_content, start=start, end=end)
-        return result.render()
+        return result.render(tool_call_id)
 
 
 class RenameFileInput(BaseModel):

--- a/src/codegen/extensions/tools/edit_file.py
+++ b/src/codegen/extensions/tools/edit_file.py
@@ -1,13 +1,17 @@
 """Tool for editing file contents."""
 
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar, Optional
 
+from langchain_core.messages import ToolMessage
 from pydantic import Field
 
 from codegen.sdk.core.codebase import Codebase
 
 from .observation import Observation
 from .replacement_edit import generate_diff
+
+if TYPE_CHECKING:
+    from .tool_output_types import EditFileArtifacts
 
 
 class EditFileObservation(Observation):
@@ -16,17 +20,34 @@ class EditFileObservation(Observation):
     filepath: str = Field(
         description="Path to the edited file",
     )
-    diff: str = Field(
+    diff: Optional[str] = Field(
+        default=None,
         description="Unified diff showing the changes made",
     )
 
     str_template: ClassVar[str] = "Edited file {filepath}"
 
-    def render(self) -> str:
+    def render(self, tool_call_id: str) -> ToolMessage:
         """Render edit results in a clean format."""
-        return f"""[EDIT FILE]: {self.filepath}
+        if self.status == "error":
+            artifacts_error: EditFileArtifacts = {"filepath": self.filepath, "error": self.error}
+            return ToolMessage(
+                content=f"[ERROR EDITING FILE]: {self.filepath}: {self.error}",
+                status=self.status,
+                tool_name="edit_file",
+                artifacts=artifacts_error,
+                tool_call_id=tool_call_id,
+            )
 
-{self.diff}"""
+        artifacts_success: EditFileArtifacts = {"filepath": self.filepath, "diff": self.diff}
+
+        return ToolMessage(
+            content=f"""[EDIT FILE]: {self.filepath}\n\n{self.diff}""",
+            status=self.status,
+            tool_name="edit_file",
+            artifacts=artifacts_success,
+            tool_call_id=tool_call_id,
+        )
 
 
 def edit_file(codebase: Codebase, filepath: str, new_content: str) -> EditFileObservation:

--- a/src/codegen/extensions/tools/edit_file.py
+++ b/src/codegen/extensions/tools/edit_file.py
@@ -35,7 +35,7 @@ class EditFileObservation(Observation):
                 content=f"[ERROR EDITING FILE]: {self.filepath}: {self.error}",
                 status=self.status,
                 tool_name="edit_file",
-                artifacts=artifacts_error,
+                artifact=artifacts_error,
                 tool_call_id=tool_call_id,
             )
 
@@ -45,7 +45,7 @@ class EditFileObservation(Observation):
             content=f"""[EDIT FILE]: {self.filepath}\n\n{self.diff}""",
             status=self.status,
             tool_name="edit_file",
-            artifacts=artifacts_success,
+            artifact=artifacts_success,
             tool_call_id=tool_call_id,
         )
 

--- a/src/codegen/extensions/tools/list_directory.py
+++ b/src/codegen/extensions/tools/list_directory.py
@@ -2,12 +2,13 @@
 
 from typing import ClassVar
 
+from langchain_core.messages import ToolMessage
 from pydantic import Field
 
+from codegen.extensions.tools.observation import Observation
+from codegen.extensions.tools.tool_output_types import ListDirectoryArtifacts
 from codegen.sdk.core.codebase import Codebase
 from codegen.sdk.core.directory import Directory
-
-from .observation import Observation
 
 
 class DirectoryInfo(Observation):
@@ -31,6 +32,14 @@ class DirectoryInfo(Observation):
         default=False,
         description="Whether this is a leaf node (at max depth)",
     )
+    depth: int = Field(
+        default=0,
+        description="Current depth in the tree",
+    )
+    max_depth: int = Field(
+        default=1,
+        description="Maximum depth allowed",
+    )
 
     str_template: ClassVar[str] = "Directory {path} ({file_count} files, {dir_count} subdirs)"
 
@@ -41,7 +50,7 @@ class DirectoryInfo(Observation):
             "dir_count": len(self.subdirectories),
         }
 
-    def render(self) -> str:
+    def render_as_string(self) -> str:
         """Render directory listing as a file tree."""
         lines = [
             f"[LIST DIRECTORY]: {self.path}",
@@ -97,6 +106,26 @@ class DirectoryInfo(Observation):
 
         return "\n".join(lines)
 
+    def to_artifacts(self) -> ListDirectoryArtifacts:
+        """Convert directory info to artifacts for UI."""
+        artifacts: ListDirectoryArtifacts = {
+            "dirpath": self.path,
+            "name": self.name,
+            "is_leaf": self.is_leaf,
+            "depth": self.depth,
+            "max_depth": self.max_depth,
+        }
+
+        if self.files is not None:
+            artifacts["files"] = self.files
+            artifacts["file_paths"] = [f"{self.path}/{f}" for f in self.files]
+
+        if self.subdirectories:
+            artifacts["subdirs"] = [d.name for d in self.subdirectories]
+            artifacts["subdir_paths"] = [d.path for d in self.subdirectories]
+
+        return artifacts
+
 
 class ListDirectoryObservation(Observation):
     """Response from listing directory contents."""
@@ -107,9 +136,29 @@ class ListDirectoryObservation(Observation):
 
     str_template: ClassVar[str] = "{directory_info}"
 
-    def render(self) -> str:
-        """Render directory listing."""
-        return self.directory_info.render()
+    def render(self, tool_call_id: str) -> ToolMessage:
+        """Render directory listing with artifacts for UI."""
+        if self.status == "error":
+            error_artifacts: ListDirectoryArtifacts = {
+                "dirpath": self.directory_info.path,
+                "name": self.directory_info.name,
+                "error": self.error,
+            }
+            return ToolMessage(
+                content=f"[ERROR LISTING DIRECTORY]: {self.directory_info.path}: {self.error}",
+                status=self.status,
+                tool_name="list_directory",
+                artifacts=error_artifacts,
+                tool_call_id=tool_call_id,
+            )
+
+        return ToolMessage(
+            content=self.directory_info.render_as_string(),
+            status=self.status,
+            tool_name="list_directory",
+            artifacts=self.directory_info.to_artifacts(),
+            tool_call_id=tool_call_id,
+        )
 
 
 def list_directory(codebase: Codebase, path: str = "./", depth: int = 2) -> ListDirectoryObservation:
@@ -136,7 +185,7 @@ def list_directory(codebase: Codebase, path: str = "./", depth: int = 2) -> List
             ),
         )
 
-    def get_directory_info(dir_obj: Directory, current_depth: int) -> DirectoryInfo:
+    def get_directory_info(dir_obj: Directory, current_depth: int, max_depth: int) -> DirectoryInfo:
         """Helper function to get directory info recursively."""
         # Get direct files (always include files unless at max depth)
         all_files = []
@@ -151,7 +200,7 @@ def list_directory(codebase: Codebase, path: str = "./", depth: int = 2) -> List
                 if current_depth > 1 or current_depth == -1:
                     # For deeper traversal, get full directory info
                     new_depth = current_depth - 1 if current_depth > 1 else -1
-                    subdirs.append(get_directory_info(subdir, new_depth))
+                    subdirs.append(get_directory_info(subdir, new_depth, max_depth))
                 else:
                     # At max depth, return a leaf node
                     subdirs.append(
@@ -161,6 +210,8 @@ def list_directory(codebase: Codebase, path: str = "./", depth: int = 2) -> List
                             path=subdir.dirpath,
                             files=None,  # Don't include files at max depth
                             is_leaf=True,
+                            depth=current_depth,
+                            max_depth=max_depth,
                         )
                     )
 
@@ -170,9 +221,11 @@ def list_directory(codebase: Codebase, path: str = "./", depth: int = 2) -> List
             path=dir_obj.dirpath,
             files=sorted(all_files),
             subdirectories=subdirs,
+            depth=current_depth,
+            max_depth=max_depth,
         )
 
-    dir_info = get_directory_info(directory, depth)
+    dir_info = get_directory_info(directory, depth, depth)
     return ListDirectoryObservation(
         status="success",
         directory_info=dir_info,

--- a/src/codegen/extensions/tools/list_directory.py
+++ b/src/codegen/extensions/tools/list_directory.py
@@ -148,7 +148,7 @@ class ListDirectoryObservation(Observation):
                 content=f"[ERROR LISTING DIRECTORY]: {self.directory_info.path}: {self.error}",
                 status=self.status,
                 tool_name="list_directory",
-                artifacts=error_artifacts,
+                artifact=error_artifacts,
                 tool_call_id=tool_call_id,
             )
 
@@ -156,7 +156,7 @@ class ListDirectoryObservation(Observation):
             content=self.directory_info.render_as_string(),
             status=self.status,
             tool_name="list_directory",
-            artifacts=self.directory_info.to_artifacts(),
+            artifact=self.directory_info.to_artifacts(),
             tool_call_id=tool_call_id,
         )
 

--- a/src/codegen/extensions/tools/observation.py
+++ b/src/codegen/extensions/tools/observation.py
@@ -3,6 +3,7 @@
 import json
 from typing import Any, ClassVar, Optional
 
+from langchain_core.messages import ToolMessage
 from pydantic import BaseModel, Field
 
 
@@ -37,13 +38,47 @@ class Observation(BaseModel):
         """Get string representation of the observation."""
         if self.status == "error":
             return f"Error: {self.error}"
-        details = self._get_details()
-        return self.render()
+        return self.render_as_string()
 
     def __repr__(self) -> str:
         """Get detailed string representation of the observation."""
         return f"{self.__class__.__name__}({self.model_dump_json()})"
 
-    def render(self) -> str:
-        """Render the observation as a string."""
+    def render_as_string(self) -> str:
+        """Render the observation as a string.
+
+        This is used for string representation and as the content field
+        in the ToolMessage. Subclasses can override this to customize
+        their string output format.
+        """
         return json.dumps(self.model_dump(), indent=2)
+
+    def render(self, tool_call_id: Optional[str] = None) -> ToolMessage | str:
+        """Render the observation as a ToolMessage or string.
+
+        Args:
+            tool_call_id: Optional[str] = None - If provided, return a ToolMessage.
+                If None, return a string representation.
+
+        Returns:
+            ToolMessage or str containing the observation content and metadata.
+            For error cases, includes error information in artifacts.
+        """
+        if tool_call_id is None:
+            return self.render_as_string()
+
+        # Get content first in case render_as_string has side effects
+        content = self.render_as_string()
+
+        if self.status == "error":
+            return ToolMessage(
+                content=content,
+                status=self.status,
+                tool_call_id=tool_call_id,
+            )
+
+        return ToolMessage(
+            content=content,
+            status=self.status,
+            tool_call_id=tool_call_id,
+        )

--- a/src/codegen/extensions/tools/search.py
+++ b/src/codegen/extensions/tools/search.py
@@ -128,7 +128,7 @@ class SearchObservation(Observation):
                 status=self.status,
                 tool_name="search",
                 tool_call_id=tool_call_id,
-                artifacts=artifacts,
+                artifact=artifacts,
             )
 
         # Build matches and file paths for success case
@@ -164,7 +164,7 @@ class SearchObservation(Observation):
             status=self.status,
             tool_name="search",
             tool_call_id=tool_call_id,
-            artifacts=artifacts,
+            artifact=artifacts,
         )
 
 

--- a/src/codegen/extensions/tools/search.py
+++ b/src/codegen/extensions/tools/search.py
@@ -10,8 +10,11 @@ import re
 import subprocess
 from typing import ClassVar, Optional
 
+from langchain_core.messages import ToolMessage
 from pydantic import Field
 
+from codegen.extensions.tools.tool_output_types import SearchArtifacts
+from codegen.extensions.tools.tool_output_types import SearchMatch as SearchMatchDict
 from codegen.sdk.core.codebase import Codebase
 
 from .observation import Observation
@@ -31,9 +34,17 @@ class SearchMatch(Observation):
     )
     str_template: ClassVar[str] = "Line {line_number}: {match}"
 
-    def render(self) -> str:
+    def render_as_string(self) -> str:
         """Render match in a VSCode-like format."""
         return f"{self.line_number:>4}:  {self.line}"
+
+    def to_dict(self) -> SearchMatchDict:
+        """Convert to SearchMatch TypedDict format."""
+        return {
+            "line_number": self.line_number,
+            "line": self.line,
+            "match": self.match,
+        }
 
 
 class SearchFileResult(Observation):
@@ -48,13 +59,13 @@ class SearchFileResult(Observation):
 
     str_template: ClassVar[str] = "{filepath}: {match_count} matches"
 
-    def render(self) -> str:
+    def render_as_string(self) -> str:
         """Render file results in a VSCode-like format."""
         lines = [
             f"📄 {self.filepath}",
         ]
         for match in self.matches:
-            lines.append(match.render())
+            lines.append(match.render_as_string())
         return "\n".join(lines)
 
     def _get_details(self) -> dict[str, str | int]:
@@ -86,11 +97,47 @@ class SearchObservation(Observation):
 
     str_template: ClassVar[str] = "Found {total_files} files with matches for '{query}' (page {page}/{total_pages})"
 
-    def render(self) -> str:
-        """Render search results in a VSCode-like format."""
-        if self.status == "error":
-            return f"[SEARCH ERROR]: {self.error}"
+    def render(self, tool_call_id: str) -> ToolMessage:
+        """Render search results in a VSCode-like format.
 
+        Args:
+            tool_call_id: ID of the tool call that triggered this search
+
+        Returns:
+            ToolMessage containing search results or error
+        """
+        # Prepare artifacts dictionary with default values
+        artifacts: SearchArtifacts = {
+            "query": self.query,
+            "error": self.error if self.status == "error" else None,
+            "matches": [],  # List[SearchMatchDict] - match data as TypedDict
+            "file_paths": [],  # List[str] - file paths with matches
+            "page": self.page,
+            "total_pages": self.total_pages if self.status == "success" else 0,
+            "total_files": self.total_files if self.status == "success" else 0,
+            "files_per_page": self.files_per_page,
+        }
+
+        # Handle error case early
+        if self.status == "error":
+            return ToolMessage(
+                content=f"[SEARCH ERROR]: {self.error}",
+                status=self.status,
+                tool_name="search",
+                tool_call_id=tool_call_id,
+                artifacts=artifacts,
+            )
+
+        # Build matches and file paths for success case
+        for result in self.results:
+            artifacts["file_paths"].append(result.filepath)
+            for match in result.matches:
+                # Convert match to SearchMatchDict format
+                match_dict = match.to_dict()
+                match_dict["filepath"] = result.filepath
+                artifacts["matches"].append(match_dict)
+
+        # Build content lines
         lines = [
             f"[SEARCH RESULTS]: {self.query}",
             f"Found {self.total_files} files with matches (showing page {self.page} of {self.total_pages})",
@@ -99,16 +146,23 @@ class SearchObservation(Observation):
 
         if not self.results:
             lines.append("No matches found")
-            return "\n".join(lines)
+        else:
+            # Add results with blank lines between files
+            for result in self.results:
+                lines.append(result.render_as_string())
+                lines.append("")  # Add blank line between files
 
-        for result in self.results:
-            lines.append(result.render())
-            lines.append("")  # Add blank line between files
+            # Add pagination info if there are multiple pages
+            if self.total_pages > 1:
+                lines.append(f"Page {self.page}/{self.total_pages} (use page parameter to see more results)")
 
-        if self.total_pages > 1:
-            lines.append(f"Page {self.page}/{self.total_pages} (use page parameter to see more results)")
-
-        return "\n".join(lines)
+        return ToolMessage(
+            content="\n".join(lines),
+            status=self.status,
+            tool_name="search",
+            tool_call_id=tool_call_id,
+            artifacts=artifacts,
+        )
 
 
 def _search_with_ripgrep(

--- a/src/codegen/extensions/tools/semantic_edit.py
+++ b/src/codegen/extensions/tools/semantic_edit.py
@@ -66,7 +66,7 @@ class SemanticEditObservation(Observation):
                 status=self.status,
                 tool_name="semantic_edit",
                 tool_call_id=tool_call_id,
-                artifacts=artifacts,
+                artifact=artifacts,
             )
 
         return ToolMessage(
@@ -74,7 +74,7 @@ class SemanticEditObservation(Observation):
             status=self.status,
             tool_name="semantic_edit",
             tool_call_id=tool_call_id,
-            artifacts=artifacts,
+            artifact=artifacts,
         )
 
 

--- a/src/codegen/extensions/tools/semantic_edit.py
+++ b/src/codegen/extensions/tools/semantic_edit.py
@@ -2,8 +2,9 @@
 
 import difflib
 import re
-from typing import ClassVar, Optional
+from typing import TYPE_CHECKING, ClassVar, Optional
 
+from langchain_core.messages import ToolMessage
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 from pydantic import Field
@@ -15,6 +16,9 @@ from .observation import Observation
 from .semantic_edit_prompts import _HUMAN_PROMPT_DRAFT_EDITOR, COMMANDER_SYSTEM_PROMPT
 from .view_file import add_line_numbers
 
+if TYPE_CHECKING:
+    from .tool_output_types import SemanticEditArtifacts
+
 
 class SemanticEditObservation(Observation):
     """Response from making semantic edits to a file."""
@@ -24,18 +28,54 @@ class SemanticEditObservation(Observation):
     )
     diff: Optional[str] = Field(
         default=None,
-        description="Unified diff showing the changes made",
+        description="Unified diff of changes made to the file",
     )
     new_content: Optional[str] = Field(
         default=None,
-        description="New content with line numbers",
+        description="New content of the file with line numbers after edits",
     )
     line_count: Optional[int] = Field(
         default=None,
-        description="Total number of lines in file",
+        description="Total number of lines in the edited file",
     )
 
     str_template: ClassVar[str] = "Edited file {filepath}"
+
+    def render(self, tool_call_id: str) -> ToolMessage:
+        """Render the observation as a ToolMessage.
+
+        Args:
+            tool_call_id: ID of the tool call that triggered this edit
+
+        Returns:
+            ToolMessage containing edit results or error
+        """
+        # Prepare artifacts dictionary with default values
+        artifacts: SemanticEditArtifacts = {
+            "filepath": self.filepath,
+            "diff": self.diff,
+            "new_content": self.new_content,
+            "line_count": self.line_count,
+            "error": self.error if self.status == "error" else None,
+        }
+
+        # Handle error case early
+        if self.status == "error":
+            return ToolMessage(
+                content=f"[EDIT ERROR]: {self.error}",
+                status=self.status,
+                tool_name="semantic_edit",
+                tool_call_id=tool_call_id,
+                artifacts=artifacts,
+            )
+
+        return ToolMessage(
+            content=self.render_as_string(),
+            status=self.status,
+            tool_name="semantic_edit",
+            tool_call_id=tool_call_id,
+            artifacts=artifacts,
+        )
 
 
 def generate_diff(original: str, modified: str) -> str:

--- a/src/codegen/extensions/tools/tool_output_types.py
+++ b/src/codegen/extensions/tools/tool_output_types.py
@@ -1,0 +1,90 @@
+"""Type definitions for tool outputs."""
+
+from typing import Optional, TypedDict
+
+
+class EditFileArtifacts(TypedDict, total=False):
+    """Artifacts for edit file operations.
+
+    All fields are optional to support both success and error cases.
+    """
+
+    filepath: str  # Path to the edited file
+    diff: Optional[str]  # Diff of changes made to the file
+    error: Optional[str]  # Error message (only present on error)
+
+
+class ViewFileArtifacts(TypedDict, total=False):
+    """Artifacts for view file operations.
+
+    All fields are optional to support both success and error cases.
+    Includes metadata useful for UI logging and pagination.
+    """
+
+    filepath: str  # Path to the viewed file
+    start_line: Optional[int]  # Starting line number viewed
+    end_line: Optional[int]  # Ending line number viewed
+    total_lines: Optional[int]  # Total number of lines in file
+    has_more: Optional[bool]  # Whether there are more lines to view
+    max_lines_per_page: Optional[int]  # Maximum lines that can be viewed at once
+    file_size: Optional[int]  # Size of file in bytes
+    error: Optional[str]  # Error message (only present on error)
+
+
+class ListDirectoryArtifacts(TypedDict, total=False):
+    """Artifacts for directory listing operations.
+
+    All fields are optional to support both success and error cases.
+    Includes metadata useful for UI tree view and navigation.
+    """
+
+    dirpath: str  # Full path to the directory
+    name: str  # Name of the directory
+    files: Optional[list[str]]  # List of files in this directory
+    file_paths: Optional[list[str]]  # Full paths to files in this directory
+    subdirs: Optional[list[str]]  # List of subdirectory names
+    subdir_paths: Optional[list[str]]  # Full paths to subdirectories
+    is_leaf: Optional[bool]  # Whether this is a leaf node (at max depth)
+    depth: Optional[int]  # Current depth in the tree
+    max_depth: Optional[int]  # Maximum depth allowed
+    error: Optional[str]  # Error message (only present on error)
+
+
+class SearchMatch(TypedDict, total=False):
+    """Information about a single search match."""
+
+    filepath: str  # Path to the file containing the match
+    line_number: int  # 1-based line number of the match
+    line: str  # The full line containing the match
+    match: str  # The specific text that matched
+
+
+class SearchArtifacts(TypedDict, total=False):
+    """Artifacts for search operations.
+
+    All fields are optional to support both success and error cases.
+    Includes metadata useful for UI search results and navigation.
+    """
+
+    query: str  # Search query that was used
+    page: int  # Current page number (1-based)
+    total_pages: int  # Total number of pages available
+    total_files: int  # Total number of files with matches
+    files_per_page: int  # Number of files shown per page
+    matches: list[SearchMatch]  # List of matches with file paths and line numbers
+    file_paths: list[str]  # List of files containing matches
+    error: Optional[str]  # Error message (only present on error)
+
+
+class SemanticEditArtifacts(TypedDict, total=False):
+    """Artifacts for semantic edit operations.
+
+    All fields are optional to support both success and error cases.
+    Includes metadata useful for UI diff view and file content.
+    """
+
+    filepath: str  # Path to the edited file
+    diff: Optional[str]  # Unified diff of changes made to the file
+    new_content: Optional[str]  # New content of the file after edits
+    line_count: Optional[int]  # Total number of lines in the edited file
+    error: Optional[str]  # Error message (only present on error)

--- a/src/codegen/extensions/tools/view_file.py
+++ b/src/codegen/extensions/tools/view_file.py
@@ -1,12 +1,16 @@
 """Tool for viewing file contents and metadata."""
 
-from typing import ClassVar, Optional
+from typing import TYPE_CHECKING, ClassVar, Optional
 
+from langchain_core.messages import ToolMessage
 from pydantic import Field
 
 from codegen.sdk.core.codebase import Codebase
 
 from .observation import Observation
+
+if TYPE_CHECKING:
+    from .tool_output_types import ViewFileArtifacts
 
 
 class ViewFileObservation(Observation):
@@ -41,8 +45,30 @@ class ViewFileObservation(Observation):
 
     str_template: ClassVar[str] = "File {filepath} (showing lines {start_line}-{end_line} of {line_count})"
 
-    def render(self) -> str:
+    def render(self, tool_call_id: str) -> ToolMessage:
         """Render the file view with pagination information if applicable."""
+        if self.status == "error":
+            error_artifacts: ViewFileArtifacts = {"filepath": self.filepath}
+            return ToolMessage(
+                content=f"[ERROR VIEWING FILE]: {self.filepath}: {self.error}",
+                status=self.status,
+                tool_call_id=tool_call_id,
+                tool_name="view_file",
+                artifacts=error_artifacts,
+                additional_kwargs={
+                    "error": self.error,
+                },
+            )
+
+        success_artifacts: ViewFileArtifacts = {
+            "filepath": self.filepath,
+            "start_line": self.start_line,
+            "end_line": self.end_line,
+            "total_lines": self.line_count,
+            "has_more": self.has_more,
+            "max_lines_per_page": self.max_lines_per_page,
+        }
+
         header = f"[VIEW FILE]: {self.filepath}"
         if self.line_count is not None:
             header += f" ({self.line_count} lines total)"
@@ -52,10 +78,13 @@ class ViewFileObservation(Observation):
             if self.has_more:
                 header += f" (more lines available, max {self.max_lines_per_page} lines per page)"
 
-        if not self.content:
-            return f"{header}\n<empty content>"
-
-        return f"{header}\n\n{self.content}"
+        return ToolMessage(
+            content=f"{header}\n\n{self.content}" if self.content else f"{header}\n<Empty Content>",
+            status=self.status,
+            tool_name="view_file",
+            tool_call_id=tool_call_id,
+            artifacts=success_artifacts,
+        )
 
 
 def add_line_numbers(content: str) -> str:
@@ -92,10 +121,12 @@ def view_file(
     """
     try:
         file = codebase.get_file(filepath)
+
     except ValueError:
         return ViewFileObservation(
             status="error",
-            error=f"File not found: {filepath}. Please use full filepath relative to workspace root.",
+            error=f"""File not found: {filepath}. Please use full filepath relative to workspace root.
+Ensure that this is indeed the correct filepath, else keep searching to find the correct fullpath.""",
             filepath=filepath,
             content="",
             line_count=0,

--- a/src/codegen/extensions/tools/view_file.py
+++ b/src/codegen/extensions/tools/view_file.py
@@ -54,7 +54,7 @@ class ViewFileObservation(Observation):
                 status=self.status,
                 tool_call_id=tool_call_id,
                 tool_name="view_file",
-                artifacts=error_artifacts,
+                artifact=error_artifacts,
                 additional_kwargs={
                     "error": self.error,
                 },
@@ -83,7 +83,7 @@ class ViewFileObservation(Observation):
             status=self.status,
             tool_name="view_file",
             tool_call_id=tool_call_id,
-            artifacts=success_artifacts,
+            artifact=success_artifacts,
         )
 
 

--- a/tests/unit/codegen/extensions/test_tools.py
+++ b/tests/unit/codegen/extensions/test_tools.py
@@ -225,14 +225,14 @@ def test_list_directory(codebase):
     core_dir = next(d for d in src_dir.subdirectories if d.name == "core")
 
     # Verify rendered output has proper tree structure
-    rendered = result.render()
+    rendered = result.render(tool_call_id="test")
     print(rendered)
     expected_tree = """
 └── src/
     ├── main.py
     ├── utils.py
     └── core/"""
-    assert expected_tree in rendered.strip()
+    assert expected_tree in rendered.content.strip()
 
 
 def test_edit_file(codebase):


### PR DESCRIPTION
See the schemas in `tool_output_types.py`

Adding schemas for the following tools:

- view_file
- edit_file
- semantic_edit
- search
- list_directory


Right now the render method is jank -> lot's of lining errors because for the tools that we are still returning a string and not a tool message, those are still a work in progress to convert to a ToolMessage. Thus, just ignore the lining errors for now