### PR TITLE
fix: CG-12266 Logging for Empty Repos + Allow Codebase Parse

### DIFF
--- a/src/codegen/git/repo_operator/repo_operator.py
+++ b/src/codegen/git/repo_operator/repo_operator.py
@@ -170,8 +170,8 @@ class RepoOperator:
         try:
             return self.git_cli.head.commit
         except ValueError as e:
-            if "Reference at 'refs/heads/main' does not exist" in str(e):
-                logger.info(f"Ref: {op.git_cli.head.ref.name} has no commits")
+            if (f"Reference at {self.git_cli.head.ref.path!r} does not exist") in str(e):
+                logger.info(f"Ref: {self.git_cli.head.ref.name} has no commits")
                 return None
             raise
 

--- a/src/codegen/git/repo_operator/repo_operator.py
+++ b/src/codegen/git/repo_operator/repo_operator.py
@@ -166,8 +166,14 @@ class RepoOperator:
         return git_cli
 
     @property
-    def head_commit(self) -> GitCommit:
-        return self.git_cli.head.commit
+    def head_commit(self) -> GitCommit | None:
+        try:
+            return self.git_cli.head.commit
+        except ValueError as e:
+            if "Reference at 'refs/heads/main' does not exist" in str(e):
+                logger.info("No commit exists in the repository yet")
+                return None
+            raise
 
     @property
     def git_diff(self) -> str:

--- a/src/codegen/git/repo_operator/repo_operator.py
+++ b/src/codegen/git/repo_operator/repo_operator.py
@@ -171,7 +171,7 @@ class RepoOperator:
             return self.git_cli.head.commit
         except ValueError as e:
             if "Reference at 'refs/heads/main' does not exist" in str(e):
-                logger.info("No commit exists in the repository yet")
+                logger.info(f"Ref: {op.git_cli.head.ref.name} has no commits")
                 return None
             raise
 

--- a/src/codegen/sdk/core/codebase.py
+++ b/src/codegen/sdk/core/codebase.py
@@ -898,6 +898,10 @@ class Codebase(
             result = self._op.checkout_commit(commit_hash=commit)
         if result == CheckoutResult.SUCCESS:
             logger.info(f"Checked out {branch or commit}")
+            if self._op.head_commit is None:
+                logger.info("No commit exists in the repository yet")
+                return CheckoutResult.SUCCESS
+
             self.sync_to_commit(self._op.head_commit)
         elif result == CheckoutResult.NOT_FOUND:
             logger.info(f"Could not find branch {branch or commit}")
@@ -1435,6 +1439,7 @@ class Codebase(
 
         with tempfile.TemporaryDirectory(prefix="codegen_") as tmp_dir:
             logger.info(f"Using directory: {tmp_dir}")
+
             codebase = CodebaseFactory.get_codebase_from_files(repo_path=tmp_dir, files=files, programming_language=prog_lang)
             logger.info("Codebase initialization complete")
             return codebase

--- a/src/codegen/sdk/core/codebase.py
+++ b/src/codegen/sdk/core/codebase.py
@@ -899,7 +899,7 @@ class Codebase(
         if result == CheckoutResult.SUCCESS:
             logger.info(f"Checked out {branch or commit}")
             if self._op.head_commit is None:
-                logger.info("No commit exists in the repository yet")
+                logger.info(f"Ref: {self._op.git_cli.head.ref.name} has no commits")
                 return CheckoutResult.SUCCESS
 
             self.sync_to_commit(self._op.head_commit)


### PR DESCRIPTION
- Branch checked out to main on empty repos,  however, no commits exist. In this case, parse the repo but log that no commits exist