### PR TITLE
fix: CG-17050: skip codebase init if repo operator is none

### DIFF
--- a/src/codegen/sdk/core/codebase.py
+++ b/src/codegen/sdk/core/codebase.py
@@ -1382,6 +1382,11 @@ class Codebase(
             else:
                 # Ensure the operator can handle remote operations
                 repo_operator = RepoOperator.create_from_commit(repo_path=repo_path, commit=commit, url=repo_url, full_name=repo_full_name, access_token=access_token)
+
+            if repo_operator is None:
+                logger.error("Failed to clone repository")
+                return None
+
             logger.info("Clone completed successfully")
 
             # Initialize and return codebase with proper context

--- a/src/codegen/sdk/core/codebase.py
+++ b/src/codegen/sdk/core/codebase.py
@@ -25,7 +25,7 @@ from typing_extensions import TypeVar, deprecated
 from codegen.configs.models.codebase import CodebaseConfig, PinkMode
 from codegen.configs.models.secrets import SecretsConfig
 from codegen.git.repo_operator.repo_operator import RepoOperator
-from codegen.git.schemas.enums import CheckoutResult, SetupOption
+from codegen.git.schemas.enums import CheckoutResult
 from codegen.git.schemas.repo_config import RepoConfig
 from codegen.git.utils.pr_review import CodegenPR
 from codegen.sdk._proxy import proxy_property
@@ -1337,7 +1337,6 @@ class Codebase(
         language: Literal["python", "typescript"] | ProgrammingLanguage | None = None,
         config: CodebaseConfig | None = None,
         secrets: SecretsConfig | None = None,
-        setup_option: SetupOption | None = None,
         full_history: bool = False,
     ) -> "Codebase":
         """Fetches a codebase from GitHub and returns a Codebase instance.

--- a/tests/integration/codegen/git/codebase/conftest.py
+++ b/tests/integration/codegen/git/codebase/conftest.py
@@ -2,12 +2,11 @@ import os
 
 import pytest
 
-from codegen.git.schemas.enums import SetupOption
 from codegen.sdk.core.codebase import Codebase
 
 
 @pytest.fixture
 def codebase(tmpdir):
     os.chdir(tmpdir)
-    codebase = Codebase.from_repo(repo_full_name="codegen-sh/Kevin-s-Adventure-Game", tmp_dir=tmpdir, language="python", setup_option=SetupOption.PULL_OR_CLONE)
+    codebase = Codebase.from_repo(repo_full_name="codegen-sh/Kevin-s-Adventure-Game", tmp_dir=tmpdir, language="python")
     yield codebase

--- a/tests/unit/codegen/sdk/core/test_codebase.py
+++ b/tests/unit/codegen/sdk/core/test_codebase.py
@@ -2,8 +2,10 @@ from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 
+from codegen.configs.models.secrets import SecretsConfig
 from codegen.sdk.codebase.codebase_context import CodebaseContext
 from codegen.sdk.codebase.factory.get_session import get_codebase_session
+from codegen.sdk.core.codebase import Codebase
 
 
 @pytest.fixture(autouse=True)
@@ -39,3 +41,9 @@ def test_codeowners_property(context_mock, codebase):
     assert len(codebase.codeowners) == 1
     assert callable(codebase.codeowners[0].files_source)
     assert codebase.codeowners[0].files_source() == codebase.files.return_value
+
+
+def test_from_codebase_non_existent_repo(context_mock, tmpdir):
+    with get_codebase_session(tmpdir=tmpdir, files={"src/main.py": "print('Hello, world!')"}, verify_output=False) as codebase:
+        codebase = Codebase.from_repo("some-org/non-existent-repo", tmp_dir=tmpdir, secrets=SecretsConfig(github_token="some-token"))
+        assert codebase is None


### PR DESCRIPTION
# Motivation
Safe handling of trying to clone a revoked github token

# Content

<!-- Please include a summary of the change -->

# Testing

<!-- How was the change tested? -->

# Please check the following before marking your PR as ready for review

- [x] I have added tests for my changes
- [x] I have updated the documentation or added new documentation as needed
