### PR TITLE
fix: make resource module usage Windows-compatible

### DIFF
--- a/docs/graph-sitter/installation.mdx
+++ b/docs/graph-sitter/installation.mdx
@@ -84,7 +84,12 @@ Having issues? Here are some common problems and their solutions:
 
 - **I'm hitting an UV error related to `[[ packages ]]`**: This means you're likely using an outdated version of UV. Try updating to the latest version with: `uv self update`.
 - **I'm hitting an error about `No module named 'codegen.sdk.extensions.utils'`**: The compiled cython extensions are out of sync. Update them with `uv sync --reinstall-package codegen`.
-- **I'm hitting a `RecursionError: maximum recursion depth exceeded` error while parsing my codebase**: If you are using python 3.12, try upgrading to 3.13. If you are already on 3.13, try upping the recursion limit with `sys.setrecursionlimit(10000)`.
+- **I'm hitting a `RecursionError: maximum recursion depth exceeded` error while parsing my codebase**: 
+  - If you are using python 3.12, try upgrading to 3.13
+  - If you are already on 3.13:
+    - On Linux/macOS: The recursion limit is automatically increased
+    - On Windows: Try increasing the recursion limit with `sys.setrecursionlimit(10000)`
+    - If issues persist, consider using WSL for better compatibility
 
 <Note>
 For more help, join our [community Slack](/introduction/community) or check the [FAQ](/introduction/faq).

--- a/src/codegen/sdk/core/file.py
+++ b/src/codegen/sdk/core/file.py
@@ -1,6 +1,5 @@
 import os
 import re
-import resource
 import sys
 from abc import abstractmethod
 from collections.abc import Generator, Sequence
@@ -438,7 +437,11 @@ class SourceFile(
         try:
             self.parse(ctx)
         except RecursionError as e:
-            logger.exception(f"RecursionError parsing file {filepath}: {e} at depth {sys.getrecursionlimit()} and {resource.getrlimit(resource.RLIMIT_STACK)}")
+            if sys.platform == "win32":
+                logger.exception(f"RecursionError parsing file {filepath}: {e} at depth {sys.getrecursionlimit()}")
+            else:
+                import resource
+                logger.exception(f"RecursionError parsing file {filepath}: {e} at depth {sys.getrecursionlimit()} and {resource.getrlimit(resource.RLIMIT_STACK)}")
             raise e
         except Exception as e:
             logger.exception(f"Failed to parse file {filepath}: {e}")

--- a/tests/shared/utils/recursion.py
+++ b/tests/shared/utils/recursion.py
@@ -1,5 +1,4 @@
 import logging
-import resource
 import sys
 
 logger = logging.getLogger(__name__)
@@ -8,5 +7,6 @@ logger = logging.getLogger(__name__)
 def set_recursion_limit():
     sys.setrecursionlimit(10**9)
     if sys.platform == "linux":
+        import resource
         logger.info(f"Setting stack limit to {resource.RLIM_INFINITY}")
         resource.setrlimit(resource.RLIMIT_STACK, (resource.RLIM_INFINITY, resource.RLIM_INFINITY))

--- a/tests/shared/utils/test_recursion.py
+++ b/tests/shared/utils/test_recursion.py
@@ -1,0 +1,30 @@
+import sys
+import pytest
+from unittest.mock import patch, MagicMock
+
+from tests.shared.utils.recursion import set_recursion_limit
+
+
+def test_set_recursion_limit_windows():
+    """Test that set_recursion_limit works on Windows without trying to import resource."""
+    with patch('sys.platform', 'win32'), \
+         patch('sys.setrecursionlimit') as mock_setrecursion, \
+         patch('importlib.import_module') as mock_import:
+        set_recursion_limit()
+        mock_setrecursion.assert_called_once_with(10**9)
+        mock_import.assert_not_called()
+
+
+def test_set_recursion_limit_linux():
+    """Test that set_recursion_limit works on Linux with resource module."""
+    mock_resource = MagicMock()
+    mock_resource.RLIM_INFINITY = -1
+    mock_resource.RLIMIT_STACK = 8
+
+    with patch('sys.platform', 'linux'), \
+         patch('sys.setrecursionlimit') as mock_setrecursion, \
+         patch('importlib.import_module', return_value=mock_resource) as mock_import:
+        set_recursion_limit()
+        mock_setrecursion.assert_called_once_with(10**9)
+        mock_import.assert_called_once_with('resource')
+        mock_resource.setrlimit.assert_called_once_with(8, (-1, -1)) 


### PR DESCRIPTION
# Motivation

`resource` module is Unix-specific and not available on windows

# Content

- In `recursion.py`: Moved `resource` import inside Linux check to prevent Windows from trying to import it
- In `file.py`: Added Windows-specific error handling while preserving original behavior for non-Windows platforms

# Testing

Wrote a test script and tested on both Ubuntu and Windows PowerShell

# Please check the following before marking your PR as ready for review

- [x] I have added tests for my changes
- [x] I have updated the documentation or added new documentation as needed
