### PR TITLE
fix: update claude mcp configuration with repo and org headers

### DIFF
--- a/docs/integrations/mcp.mdx
+++ b/docs/integrations/mcp.mdx
@@ -23,10 +23,16 @@ The remote MCP server provides:
 To configure the remote Codegen MCP server in Claude Code:
 
 ```bash
-claude mcp add --transport http codegen-tools https://mcp.codegen.com/mcp/ --header "Authorization: Bearer <auth token>"
+claude mcp add --transport http codegen-tools https://mcp.codegen.com/mcp/ \
+  --header "Authorization: Bearer <auth token>" \
+  --header "x-organization-id: <org-id>" \
+  --header "x-repo-id: <repo-id>"
 ```
 
-Replace `<auth token>` with your Codegen API key.
+Replace:
+- `<auth token>` with your Codegen API key
+- `<org-id>` with your organization ID (optional, automatically added when using `codegen claude`)
+- `<repo-id>` with your repository ID (optional, automatically added when using `codegen claude`)
 
 ### For Cursor/Windsurf/VSCode Forks
 
@@ -39,14 +45,19 @@ Add the following configuration to your settings:
       "transport": "http",
       "url": "https://mcp.codegen.com/mcp/",
       "headers": {
-        "Authorization": "Bearer <auth token>"
+        "Authorization": "Bearer <auth token>",
+        "x-organization-id": "<org-id>",
+        "x-repo-id": "<repo-id>"
       }
     }
   }
 }
 ```
 
-Replace `<auth token>` with your Codegen API key.
+Replace:
+- `<auth token>` with your Codegen API key
+- `<org-id>` with your organization ID (optional)
+- `<repo-id>` with your repository ID (optional)
 
 ### For VSCode with MCP Extension
 
@@ -60,14 +71,19 @@ If you're using VSCode with an MCP extension, add this to your settings.json:
       "transport": "http",
       "url": "https://mcp.codegen.com/mcp/",
       "headers": {
-        "Authorization": "Bearer <auth token>"
+        "Authorization": "Bearer <auth token>",
+        "x-organization-id": "<org-id>",
+        "x-repo-id": "<repo-id>"
       }
     }
   ]
 }
 ```
 
-Replace `<auth token>` with your Codegen API key.
+Replace:
+- `<auth token>` with your Codegen API key
+- `<org-id>` with your organization ID (optional)
+- `<repo-id>` with your repository ID (optional)
 
 ## Authentication
 

--- a/src/codegen/cli/commands/claude/config/mcp_setup.py
+++ b/src/codegen/cli/commands/claude/config/mcp_setup.py
@@ -6,7 +6,7 @@ from codegen.cli.commands.claude.quiet_console import console
 from codegen.cli.commands.claude.utils import resolve_claude_path
 
 
-def add_codegen_mcp_server():
+def add_codegen_mcp_server(org_id: int | None = None, repo_id: int | None = None):
     console.print("🔧 Configuring MCP server 'codegen-tools'...", style="blue")
     try:
         token = get_current_token()
@@ -19,18 +19,31 @@ def add_codegen_mcp_server():
             console.print("⚠️  'claude' CLI not found to add MCP server", style="yellow")
             return
 
+        # Build the command with required headers
+        cmd = [
+            claude_path,
+            "mcp",
+            "add",
+            "--transport",
+            "http",
+            "codegen-tools",
+            MCP_SERVER_ENDPOINT,
+            "--header",
+            f"Authorization: Bearer {token}",
+        ]
+
+        # Add organization ID header if available
+        if org_id is not None:
+            cmd.extend(["--header", f"x-organization-id: {org_id}"])
+            console.print(f"  Adding organization ID: {org_id}", style="dim")
+
+        # Add repository ID header if available
+        if repo_id is not None:
+            cmd.extend(["--header", f"x-repo-id: {repo_id}"])
+            console.print(f"  Adding repository ID: {repo_id}", style="dim")
+
         add_result = subprocess.run(
-            [
-                claude_path,
-                "mcp",
-                "add",
-                "--transport",
-                "http",
-                "codegen-tools",
-                MCP_SERVER_ENDPOINT,
-                "--header",
-                f"Authorization: Bearer {token}",
-            ],
+            cmd,
             capture_output=True,
             text=True,
             timeout=15,

--- a/src/codegen/cli/commands/claude/main.py
+++ b/src/codegen/cli/commands/claude/main.py
@@ -27,6 +27,7 @@ from codegen.cli.commands.claude.quiet_console import console
 from codegen.cli.commands.claude.utils import resolve_claude_path
 from codegen.cli.rich.spinners import create_spinner
 from codegen.cli.utils.org import resolve_org_id
+from codegen.cli.utils.repo import resolve_repo_id
 from codegen.shared.logging.get_logger import get_logger
 
 # Initialize logger
@@ -218,7 +219,11 @@ def _run_claude_interactive(resolved_org_id: int, no_mcp: bool | None) -> None:
 
     # If MCP endpoint provided, register MCP server via Claude CLI before launch
     if not no_mcp:
-        add_codegen_mcp_server()
+        # Resolve repository ID if available
+        repo_id = resolve_repo_id()
+        if repo_id:
+            console.print(f"🎯 Repository ID: {repo_id}", style="dim")
+        add_codegen_mcp_server(org_id=resolved_org_id, repo_id=repo_id)
 
     console.print("🔵 Starting Claude Code session...", style="blue")
 


### PR DESCRIPTION
# Motivation
Codegen MCP server takes in option repo and org id for the initialization of the mcp session

<!-- Why is this change necessary? -->

# Content

<!-- Please include a summary of the change -->

Set the organization and repo id headers when setting up claude with the codegen mcp

# Testing

<!-- How was the change tested? -->

# Please check the following before marking your PR as ready for review

- [ ] I have added tests for my changes
- [ x] I have updated the documentation or added new documentation as needed
