### PR TITLE
Silence Claude stop hook stdout

### DIFF
--- a/src/codegen/cli/commands/claude/config/claude_session_stop_hook.py
+++ b/src/codegen/cli/commands/claude/config/claude_session_stop_hook.py
@@ -56,13 +56,16 @@ def main():
         if update_claude_session_status and session_id:
             update_claude_session_status(session_id, "COMPLETE", org_id)
 
-        # Print minimal output to avoid noisy hooks
-        print(json.dumps({"session_id": session_id, "status": "COMPLETE"}))
+        # Stop hooks must stay silent on stdout unless they emit a valid decision object.
+        # This hook only performs a backend side effect, so it should not print anything.
+        return 0
 
     except Exception as e:
-        # Ensure hook doesn't fail Claude if something goes wrong
-        print(json.dumps({"error": str(e)}))
+        # Ensure hook doesn't fail Claude if something goes wrong.
+        # Log to stderr only so stdout remains a valid empty hook response.
+        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/unit/codegen/cli/test_claude_session_stop_hook.py
+++ b/tests/unit/codegen/cli/test_claude_session_stop_hook.py
@@ -1,0 +1,32 @@
+from contextlib import redirect_stderr, redirect_stdout
+from importlib.util import module_from_spec, spec_from_file_location
+from io import StringIO
+from pathlib import Path
+
+
+def load_module():
+    repo = Path(__file__).resolve().parents[4]
+    path = repo / "src" / "codegen" / "cli" / "commands" / "claude" / "config" / "claude_session_stop_hook.py"
+    spec = spec_from_file_location("test_codegen_claude_session_stop_hook", path)
+    module = module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_stop_hook_stays_silent_on_stdout(monkeypatch):
+    module = load_module()
+    calls = []
+    monkeypatch.setenv("CODEGEN_CLAUDE_SESSION_ID", "session-123")
+    monkeypatch.setenv("CODEGEN_CLAUDE_ORG_ID", "42")
+    monkeypatch.setattr(module, "update_claude_session_status", lambda session_id, status, org_id: calls.append((session_id, status, org_id)))
+
+    stdout = StringIO()
+    stderr = StringIO()
+    with redirect_stdout(stdout), redirect_stderr(stderr):
+        code = module.main()
+
+    assert code == 0
+    assert stdout.getvalue() == ""
+    assert stderr.getvalue() == ""
+    assert calls == [("session-123", "COMPLETE", 42)]


### PR DESCRIPTION
## Summary
- stop the Claude stop hook from printing non-decision JSON to stdout while keeping the backend COMPLETE status update
- send hook errors to stderr and return cleanly so Claude sees a valid empty stop-hook response
- add a regression test that proves the stop hook stays silent on stdout

## Test Plan
- python3 -m pytest -o addopts='' /private/tmp/codegen-sdk/tests/unit/codegen/cli/test_claude_session_stop_hook.py
